### PR TITLE
Fix --envs filter

### DIFF
--- a/testplan.py
+++ b/testplan.py
@@ -239,6 +239,8 @@ class Manager:
 
       for suite_num, suite in enumerate(env.suites):
         do_suite = do_env and suite.selected()
+        if not do_suite:
+          continue
         visit_testcase = visit_suite(suite_num, suite, do_suite)
         if not visit_testcase:
           continue


### PR DESCRIPTION
`sampletester --envs` was blowing up for me

```
$ sampletester --envs node talent/v4beta1/*.yaml
SKIPPED: Test environment: "php"
Traceback (most recent call last):
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/sampletester", line 250, in <module>
    main()
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/sampletester", line 95, in main
    success = manager.accept(visitor)
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/testplan.py", line 242, in accept
    visit_testcase = visit_suite(suite_num, suite, do_suite)
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/testplan.py", line 179, in <lambda>
    do_suite, start),
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/testplan.py", line 184, in visit_suite
    start = [visit(idx, suite, doit) for visit in visit_fns]
  File "/Users/rebeccataylor/code/beccasaurus/sample-tester/testplan.py", line 184, in <listcomp>
    start = [visit(idx, suite, doit) for visit in visit_fns]
TypeError: 'NoneType' object is not callable
```

The case suites for the skipped environment were (and still are) being visited.  
But visiting the test cases of a skipped suite was breaking. This is my fix.

Works for me now, after `continue`'ing when `do_suite = False`

I didn't spot any tests to update to reproduce this, but feel free to point me in the right direction and I'll repro with a test.