### PR TITLE
Add CircleCI script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/sample-tester
+    docker:
+      - image: circleci/python:3.7.2
+    steps:
+      - checkout
+      - run: echo "A first hello"
+      - run:
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip setuptools
+            pipenv install .
+            python3 -m unittest discover -s . -p '*_test.py' -v


### PR DESCRIPTION
Add a script to execute the sample-tester tests.

I added this on my fork and configured it so you could see working output:
 - [Add CircleCI script](https://github.com/beccasaurus/sample-tester/pull/1)

You can see the tests ran successfully.

When I sent a PR to the repo, the PR _automatically_ displayed the new check for CircleCI, no configuration necessary.