### PR TITLE
Ensure assertion failure preempts subsequent test case segments

### DIFF
--- a/docs/defining-tests/testplan-reference.rst
+++ b/docs/defining-tests/testplan-reference.rst
@@ -22,23 +22,24 @@ how to run the samples and what checks to perform.
    - ``uuid``: return a uuid (if called from yaml, assign it to the
      variable names as an argument)
    - ``shell``: run in the shell the command specified in the argument
-   - ``call``: call the artifact named in the argument, error if the
+   - ``call``: call the artifact named in the argument; error if the
      call fails
-   - ``call_may_fail``: call the artifact named in the argument, do
+   - ``call_may_fail``: call the artifact named in the argument; do
      not error even if the call fails
    - ``assert_contains``: require the given variable to contain a
-     string
+     string; abort the test case otherwise
    - ``assert_not_contains``: require the given variable to not
-     contain a string
+     contain a string; abort the test case otherwise
    - ``assert_success``: require that the exit code of the last
-     ``call_may_fail`` was 0. If the preceding call was a just a
-     ``call``, it would have already failed on a non-zero exit code.
+     ``call_may_fail`` was 0; abort the test case otherwise. If the
+     preceding call was a just a ``call``, it would have already
+     failed on a non-zero exit code.
    - ``assert_failure``: require that the exit code of the last
-     ``call_may_fail`` or ``call`` was NOT 0. Note, though, that if
-     we're executing this after just a ``call``, it must have
-     succeeded so this assertion will fail.
+     ``call_may_fail`` or ``call`` was NOT 0; abort the test case
+     otherwise. Note, though, that if we're executing this after just
+     a ``call``, it must have succeeded so this assertion will fail.
    - ``env``: assign the value of an environment variable to a
-     testcase variable
+     test case variable
    - ``code``: execute the argument as a chunk of Python code. The
      other directives above are available as Python calls with the
      names above. In addition, the following functions are available
@@ -46,7 +47,8 @@ how to run the samples and what checks to perform.
      
       - ``fail``: mark the test as having failed, but continue executing
       - ``abort``: mark the test as having failed and stop executing
-      - ``assert_that``: if the condition in the first argument is false, abort the test
+      - ``assert_that``: if the condition in the first argument is
+        false, abort the test case
 
 Here is an informative instance of a sample testfile:
 

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -124,7 +124,7 @@ class TestCase:
     if not condition:
       self.record_failure("FAILED ASSERTION", message, *args)
       self.print_out("# FAILED ASSERTION: " + message, *args)
-      raise TestError
+      raise TestFailure
 
   # Explicitly fails and soft-aborts the test.
   def abort(self):
@@ -256,15 +256,14 @@ class TestCase:
       for spec_segment in stage_spec:
         try:
           self.run_segment(spec_segment)  # this is a list of maps!
-        except TestError:
-          pass
+        except TestFailure:
+          break
         except Exception as e:
           status = "UNHANDLED EXCEPTION in stage {} ".format(stage_name)
           short_description = repr(e)
           description = short_description + "\n" + "".join( traceback.format_tb(e.__traceback__))
           self.record_error(status, description)
           self.print_out("# EXCEPTION!! " + short_description)
-
           break
 
     print_output = True
@@ -440,12 +439,12 @@ class TestCase:
     return [self.local_symbols.get(p, '"{}"'.format(str(p))) for p in variables]
 
 
-class TestError(Exception):
+class TestFailure(Exception):
+  """Exception raised when a test fails (typically via an assertion)."""
   pass
 
 
 class ConfigError(Exception):
-
   def __init__(self, msg):
     self.msg = msg
 

--- a/tests/caserunner_test.py
+++ b/tests/caserunner_test.py
@@ -76,24 +76,37 @@ class TestCaseRunner(unittest.TestCase):
 
   def test_all(self):
     for suite_name in list(self.results.suites.keys()):
-      if 'Passing' in suite_name:
-        self.check(suite_name, self.assertTrue,
+      if 'passing' in suite_name.lower():
+        self.check_success(suite_name, self.assertTrue,
                    'expected valid test suite to pass')
-      elif 'Failing' in suite_name:
-        self.check(suite_name, self.assertFalse,
+      elif 'failing' in suite_name.lower():
+        self.check_success(suite_name, self.assertFalse,
                    'expected failing test suite to fail')
       else:
         self.fail(
-            'found neither  "Passing" or "Failing" in suite name "{}"'.format(
-                suite_name))
+            'found neither "passing" nor "failing" in suite name "{}"'
+            .format(suite_name))
 
-  def check(self, suite_name, assertion, message):
-    assertion(self.results.suites[suite_name].success(), '{}: {}'.format(
-        message, suite_name))
+      if 'erroring' in suite_name.lower():
+        self.check_error(suite_name, self.assertFalse, 'expected test suite to error')
+      else:
+        self.check_error(suite_name, self.assertTrue, 'expected test suite to not error')
+
+  def check_success(self, suite_name, assertion, message):
     assertion(self.results.cases[suite_name + ':code'].success(),
               '{}: {}:code'.format(message, suite_name))
     assertion(self.results.cases[suite_name + ':yaml'].success(),
               '{}: {}:yaml'.format(message, suite_name))
+    assertion(self.results.suites[suite_name].success(),
+              '{}: {}'.format(message, suite_name))
+
+  def check_error(self, suite_name, assertion, message):
+    assertion(self.results.cases[suite_name + ':code'].num_errors == 0,
+                     '{}: {}:code'.format(message, suite_name))
+    assertion(self.results.cases[suite_name + ':yaml'].num_errors == 0,
+                     '{}: {}:yaml'.format(message, suite_name))
+    assertion(self.results.suites[suite_name].num_errors == 0,
+                    '{}: {}'.format(message, suite_name))
 
 
 if __name__ == '__main__':

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -63,7 +63,7 @@ test:
       - log:
         - "uuid: {}"
         - my_uuid
-  - name: Failing env
+  - name: Failing, erroring env
     cases:
     - name: code
       spec:
@@ -132,6 +132,54 @@ test:
       - assert_not_contains:
         - message: "claim this is not in there"
         - literal: "best"
+  - name: Failing test when failing assertion stops test case from running next segment (should not error)
+    setup:
+    - code: |
+        executed_after_failure = False
+    teardown:
+    - code: |
+        if executed_after_failure:
+          pass
+          raise Exception('a test case segment was executed after a previous segment failed')
+    cases:
+    - name: code
+      spec:
+      - code: |
+          abort()
+      - code: |
+          executed_after_failure = True # in a later segment than the abort()
+    - name: yaml
+      spec:
+      - code: out = call('/bin/echo', 'It was the best of times')
+      - assert_not_contains:
+        - message: "claim this is not in there"
+        - literal: "best"
+      - code: |
+          executed_after_failure = True
+  - name: Failing test when failure stops test case segment from continuing (should not error)
+    # This error-handling mode is specific to "code" specs.
+    setup:
+    - code: |
+        executed_after_failure = False
+    teardown:
+    - code: |
+        if executed_after_failure:
+          pass
+          raise Exception('a test case segment was executed after a previous failure')
+    cases:
+    - name: code
+      spec:
+      - code: |
+          abort()
+          executed_after_failure = True # in the same segment as the abort()
+    - name: yaml # same as in the previous test suite
+      spec:
+      - code: out = call('/bin/echo', 'It was the best of times')
+      - assert_not_contains:
+        - message: "claim this is not in there"
+        - literal: "best"
+      - code: |
+          executed_after_failure = True
 
           
 


### PR DESCRIPTION
This PR subsumes #4 by @beccasaurus  (thank you for finding this!) to fix #3 to include tests and deal with merge conflicts.

- When a segment of a test case fails, it will now pre-empt the execution of later test case segment
- Includes tests for this, and incidentally the testing infrastructure for verifying test case errors (as opposed to just failures)