### PR TITLE
Fix MultiVisitor to not call None visit functions

### DIFF
--- a/sampletester/summary.py
+++ b/sampletester/summary.py
@@ -88,7 +88,7 @@ class SummaryVisitor(testplan.Visitor):
       return 'SKIPPED'
     if not obj.attempted:
       if self.verbosity == Detail.FULL:
-        return 'PREEMPTED'
+        return 'PREEMPTED' # by an error
       return None
     if not obj.completed:
       return 'RUNNING'

--- a/sampletester/testplan.py
+++ b/sampletester/testplan.py
@@ -172,23 +172,23 @@ class MultiVisitor(Visitor):
     self.visitors = visitors
 
   def start_visit(self):
-    start_end = [visitor.start_visit() for visitor in self.visitors]
-    start = [fns[0] for fns in start_end]
-    end = [fns[1] for fns in start_end]
+    start_end = [visitor.start_visit() for visitor in self.visitors if visitor]
+    start = [fn[0] for fn in start_end]
+    end = [fn[1] for fn in start_end]
     return (lambda env, do_env: self.visit_environment(env, do_env, start),
             lambda env, do_env: self.visit_environment_end(env, do_env, end))
 
   def visit_environment(self, environment: Environment, doit: bool, visit_fns):
-    start_end = [visit(environment, doit) for visit in visit_fns]
-    start = [fns[0] for fns in start_end]
-    end = [fns[1] for fns in start_end]
+    start_end = [visit(environment, doit) for visit in visit_fns if visit]
+    start = [fn[0] for fn in start_end]
+    end = [fn[1] for fn in start_end]
     return (lambda idx, suite, do_suite: self.visit_suite(idx, suite,
                                                           do_suite, start),
             lambda idx, suite, do_suite: self.visit_suite_end(idx, suite,
                                                               do_suite, end))
 
   def visit_suite(self, idx: int, suite: Suite, doit: bool, visit_fns):
-    start = [visit(idx, suite, doit) for visit in visit_fns]
+    start = [visit(idx, suite, doit) for visit in visit_fns if visit]
     return lambda idx, testcase, do_case: self.visit_testcase(idx, testcase,
                                                               do_case, start)
 


### PR DESCRIPTION
Fixes #19:  The MultiVisitor was not skipping any `None` visit functions returned by its child `Visitor`s.

Note that we always want all the visitors to visit all the nodes in the hierarchy, even if they are to be skipped. Each visitor at a node should decide what to do if the node is skipped. (Rationale: we want to be able to report on the skipped nodes to, even if no tests executed there.) 

I'll add tests to `MultiVisitor` separately (#21)