### PR TITLE
Print failing caserunner test suite name

### DIFF
--- a/tests/caserunner_test.py
+++ b/tests/caserunner_test.py
@@ -73,10 +73,10 @@ class TestCaseRunner(unittest.TestCase):
     for suite_name in list(self.results.suites.keys()):
       if 'passing' in suite_name.lower():
         self.check_success(suite_name, self.assertTrue,
-                   'expected valid test suite to pass')
+                   'expected valid test suite to pass: {}'.format(suite_name))
       elif 'failing' in suite_name.lower():
         self.check_success(suite_name, self.assertFalse,
-                   'expected failing test suite to fail')
+                   'expected failing test suite to fail: {}'.format(suite_name))
       else:
         self.fail(
             'found neither "passing" nor "failing" in suite name "{}"'


### PR DESCRIPTION
Small, but helped me know which test suite was not 'passing' or 'failing' as promised by its suite name