### PR TITLE
Extract patterns from output with `extract_match`

### DIFF
--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -66,6 +66,7 @@ class TestCase:
         "uuid": (self.get_uuid, self.yaml_get_uuid),
         "env": (self.get_env, self.yaml_get_env),
         "log": (self.print_out, self.yaml_args_string),
+        "extract_match": (self.extract_match, self.yaml_extract_match),
 
         # Code
         "code": (self.execute, lambda p: ([p], {})),
@@ -87,8 +88,6 @@ class TestCase:
         # the test to continue even if an expectation is not met).
         # "expect_contains": (self.expect_contains, self.params_for_contains),
         # "expect_not_contains": (self.expect_not_contains, self.params_for_contains),
-
-        "extract_match": (self.extract_match, self.yaml_extract_match),
     }
 
     self.local_symbols = {}

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -184,11 +184,10 @@ class TestCase:
       captures = match.groups()
       if variable:
         self.local_symbols[variable] = captures[0]
-
-    if group_variables:
-      for idx, variable_name in enumerate(group_variables):
-        if len(captures) > idx:
-          self.local_symbols[variable_name] = captures[idx]
+      if group_variables:
+        for idx, variable_name in enumerate(group_variables):
+          if len(captures) > idx:
+            self.local_symbols[variable_name] = captures[idx]
     return None, None
 
   # Extracts regular expression captures from output via code.

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -16,10 +16,10 @@ import copy
 from datetime import datetime
 import logging
 import os
+import re
 import subprocess
 import traceback
 import uuid
-import re
 
 from sampletester import testenv
 

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -169,7 +169,9 @@ class TestCase:
     if not pattern:
       raise ConfigError("extract_match requires pattern to match")
     if not variable and not group_variables:
-      raise ConfigError("extract_match requires variable or group_variables")
+      raise ConfigError("extract_match requires variable or groups")
+    if variable and group_variables:
+      raise ConfigError("extract_match cannot accept both variables and groups")
 
     # Add all variable names to local_symbols (None is OK value if no match)
     self.local_symbols[variable] = None

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -163,8 +163,7 @@ class TestCase:
     self.local_symbols[var_name] = self.get_env(env_var)
     return None, None
 
-  # Extracts first regular expression capture via code. `None` as results OK.
-  # Like the assert_* calls, this only operates on self.last_call_output.
+  # Extracts regular expression captures from output via code.
   def extract_match(self, pattern, variable=None, group_variables=None):
     if not pattern:
       raise ConfigError("extract_match requires pattern to match")
@@ -192,7 +191,7 @@ class TestCase:
           self.local_symbols[variable_name] = captures[idx]
     return None, None
 
-  # Gets an environment variable via YAML.
+  # Extracts regular expression captures from output via code.
   def yaml_extract_match(self, parts):
     key_pattern = 'pattern'
     key_variable = 'variable'

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -194,9 +194,8 @@ class TestCase:
     key_pattern = 'pattern'
     key_variable = 'variable'
     key_groups = 'groups'
-    self.extract_match(parts.get(key_pattern), parts.get(key_variable),
-      parts.get(key_groups))
-    return None, None
+    return [parts.get(key_pattern), parts.get(key_variable),
+      parts.get(key_groups)], None
 
   # Invokes `cmd` (formatted with `params`). Does not fail in case of error.
   def call_allow_error(self, *args, **kwargs):

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -257,3 +257,4 @@ test:
           - third_capture # not matched
       - assert_success:
         - if extract_match fails, this is not run
+

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -182,6 +182,59 @@ test:
         - literal: "best"
       - code: |
           executed_after_failure = True
-
-          
-
+  - name: Passing extract_match (single captured variable)
+    cases:
+    - name: "code"
+      spec:
+      - code: |
+          shell('/bin/echo', '"It was the best of times"')
+          extract_match('It was the best of (.*)', 'the_best_of')
+          shell('/bin/echo', 'Captured: {}'.format(the_best_of))
+          assert_contains('Captured: times')
+    - name: "yaml"
+      spec:
+      - shell:
+        - /bin/echo "It was the best of times"
+      - extract_match:
+          pattern: "It was the best of (.*)"
+          variable: the_best_of
+      - shell:
+        - /bin/echo
+        - "Captured:"
+        - the_best_of
+      - assert_contains:
+        - literal: "Captured: times"
+  - name: Passing extract_match (multiple captured group variables)
+    cases:
+    - name: "code"
+      spec:
+      - code: |
+          shell('/bin/echo', '"It was the best of times"')
+          extract_match('^([^\\s]+) was (.*) of', 'default_match_variable',
+            ['first_capture', 'second_capture', 'third_capture'])
+          shell('/bin/echo', 'Default:', default_match_variable, 'First: ',
+            first_capture, 'Second:', second_capture, 'Third:', third_capture)
+          assert_contains('Default: It First: It Second: the best Third: None')
+    - name: "yaml"
+      spec:
+      - shell:
+        - /bin/echo "It was the best of times"
+      - extract_match:
+          pattern: ^([^\s]+) was (.*) of
+          variable: default_match_variable
+          groups:
+          - first_capture
+          - second_capture
+          - third_capture # not matched
+      - shell:
+        - /bin/echo
+        - "Default:"
+        - default_match_variable
+        - "First:"
+        - first_capture
+        - "Second:"
+        - second_capture
+        - "Third:"
+        - third_capture
+      - assert_contains:
+        - literal: 'Default: It First: It Second: the best Third: None'

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -210,26 +210,23 @@ test:
       spec:
       - code: |
           shell('/bin/echo', '"It was the best of times"')
-          extract_match('^([^\\s]+) was (.*) of', 'default_match_variable',
-            ['first_capture', 'second_capture', 'third_capture'])
-          shell('/bin/echo', 'Default:', default_match_variable, 'First: ',
-            first_capture, 'Second:', second_capture, 'Third:', third_capture)
-          assert_contains('Default: It First: It Second: the best Third: None')
+          extract_match('^([^\\s]+) was (.*) of',
+            group_variables=['first_capture', 'second_capture', 'third_capture'])
+          shell('/bin/echo', 'First: ', first_capture, 'Second:', second_capture,
+            'Third:', third_capture)
+          assert_contains('First: It Second: the best Third: None')
     - name: "yaml"
       spec:
       - shell:
         - /bin/echo "It was the best of times"
       - extract_match:
           pattern: ^([^\s]+) was (.*) of
-          variable: default_match_variable
           groups:
           - first_capture
           - second_capture
           - third_capture # not matched
       - shell:
         - /bin/echo
-        - "Default:"
-        - default_match_variable
         - "First:"
         - first_capture
         - "Second:"
@@ -237,4 +234,26 @@ test:
         - "Third:"
         - third_capture
       - assert_contains:
-        - literal: 'Default: It First: It Second: the best Third: None'
+        - literal: 'First: It Second: the best Third: None'
+  - name: Failing, erroring extract_match (cannot use variable together with groups)
+    cases:
+    - name: "code"
+      spec:
+      - code: |
+          shell('/bin/echo', '"It was the best of times"')
+          extract_match('^([^\\s]+) was (.*) of', variable='my_variable'
+            group_variables=['first_capture', 'second_capture', 'third_capture'])
+          assert_success('if extract_match fails, this is not run')
+    - name: "yaml"
+      spec:
+      - shell:
+        - /bin/echo "It was the best of times"
+      - extract_match:
+          pattern: ^([^\s]+) was (.*) of
+          variable: my_variable
+          groups:
+          - first_capture
+          - second_capture
+          - third_capture # not matched
+      - assert_success:
+        - if extract_match fails, this is not run


### PR DESCRIPTION
```yaml
extract_match:
  pattern: projects/(.*)
  variable: project_id

extract_match:
  pattern: projects/(.*)/companies/(.*)
  groups:
  - project_id
  - company_id
```

This is the last blocker for my to use sample-tester with my samples.