### PR TITLE
 Remove unnecessary step from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       - image: circleci/python:3.7.2
     steps:
       - checkout
-      - run: echo "A first hello"
       - run:
           command: |
             python3 -m venv venv


### PR DESCRIPTION
I believe this is left over from creating the config using the
Getting Started documentation examples.