### PR TITLE
Tweak case runner: _last_call_output

### DIFF
--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -55,7 +55,7 @@ class TestCase:
         # Variables: meta info about the test case, last output
         "testcase_num": (self.idx, None),
         "testcase_id": (self.label, None),
-        "last_call_output": (self.last_call_output, None),
+        "_last_call_output": (self.last_call_output, None),
 
         # Functions to execute processes
         "call": (self.call_no_error, self.params_for_call),
@@ -194,7 +194,7 @@ class TestCase:
       self.last_return_code = return_code
       # TODO: De-dupe the following. Either some accessor magic, or have it live in local_symbols
       self.last_call_output = new_output
-      self.local_symbols['last_call_output'] = new_output
+      self.local_symbols['_last_call_output'] = new_output
 
       self.output += new_output
       return return_code, new_output
@@ -362,7 +362,8 @@ class TestCase:
     """Gets printf-style arguments from a YAML directive.
 
     Interprets `parts` as a list whose first element is a print string (without
-    argument substitution) and whose subsequent elements are local symbol names.
+    argument substitution) and whose subsequent elements are local symbol names
+    or string literals.
 
     Returns the list with the names of the symbols substituted by their values
     in the self.local_symbols.
@@ -458,8 +459,14 @@ class TestCase:
                 type, item))
     return item
 
-  def lookup_values(self, variables):
-    return [self.local_symbols.get(p, '"{}"'.format(str(p))) for p in variables]
+  def lookup_values(self, strings):
+    """Returns a list containing variable values and/or literals.
+
+    For each string in the input, the corresponding output element is either the
+    value of the variable with that name, if such exists, or the quoted string
+    itself..
+    """
+    return [self.local_symbols.get(p, '"{}"'.format(str(p))) for p in strings]
 
 
 class TestFailure(Exception):

--- a/tests/caserunner_test.py
+++ b/tests/caserunner_test.py
@@ -86,9 +86,11 @@ class TestCaseRunner(unittest.TestCase):
             .format(suite_name))
 
       if 'erroring' in suite_name.lower():
-        self.check_error(suite_name, self.assertFalse, 'expected test suite to error')
+        self.check_error(suite_name, self.assertFalse,
+                         'expected test suite to error: {}'.format(suite_name))
       else:
-        self.check_error(suite_name, self.assertTrue, 'expected test suite to not error')
+        self.check_error(suite_name, self.assertTrue,
+                         'expected test suite to not error: {}'.format(suite_name))
 
   def check_success(self, suite_name, assertion, message):
     assertion(self.results.cases[suite_name + ':code'].success(),

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -29,13 +29,13 @@ test:
           assert_not_contains("worst")
           assert_that('ime' in out, 'expected "ime" in the preceding output')
           expect('ime' in out, 'expected "ime" in the preceding output')
-          assert_that('ime' in last_call_output, 'expected "ime" in the last_call_output')
+          assert_that('ime' in _last_call_output, 'expected "ime" in the preceding output')
 
           call('output', 'Greetings')
           assert_success("call should have succeeded")
           assert_contains("ree")
           assert_not_contains("farewell")
-          assert_that('eti' in last_call_output, 'expected "eti" in the preceding output')
+          assert_that('eti' in _last_call_output, 'expected "eti" in the preceding output')
 
           shell('/nonexistent/dir/foobar')
           assert_failure("foobar call should have failed")


### PR DESCRIPTION
Prepend underscore to the local symbol `_last_call_output`, in order
to not pollute the namespace available to users.

Also print the suite name when testing for errors.