### PR TITLE
Change the tag convention to use `environment` and `sample`

### DIFF
--- a/docs/defining-tests/language.manifest.yaml
+++ b/docs/defining-tests/language.manifest.yaml
@@ -20,11 +20,11 @@ sets:
   path: "examples/mock-samples/googleapis/artman-genfiles/python/language-v1/samples/google/cloud/language_v1/gapic/"
   __items__:
   - path: "analyze_sentiment/analyze_sentiment_request_language_sentiment_text.py"
-    region_tag: "language_analyze_sentiment_text"
+    sample: "language_analyze_sentiment_text"
 - environment: go
   # notice: no "bin:" because artifacts are already executable
   path: "examples/mock-samples/googleapis/artman-genfiles/go/language-v1/samples/google/cloud/language_v1/gapic/"
   __items__:
   - path: "analyze_sentiment/analyze_sentiment.go"
-    region_tag: "language_analyze_sentiment_text"
+    sample: "language_analyze_sentiment_text"
     

--- a/docs/defining-tests/language.manifest.yaml
+++ b/docs/defining-tests/language.manifest.yaml
@@ -15,13 +15,13 @@
 # Example manifest file
 version: 1
 sets:
-- language: python
+- environment: python
   bin: "python3"
   path: "examples/mock-samples/googleapis/artman-genfiles/python/language-v1/samples/google/cloud/language_v1/gapic/"
   __items__:
   - path: "analyze_sentiment/analyze_sentiment_request_language_sentiment_text.py"
     region_tag: "language_analyze_sentiment_text"
-- language: go
+- environment: go
   # notice: no "bin:" because artifacts are already executable
   path: "examples/mock-samples/googleapis/artman-genfiles/go/language-v1/samples/google/cloud/language_v1/gapic/"
   __items__:

--- a/docs/defining-tests/manifest-reference.rst
+++ b/docs/defining-tests/manifest-reference.rst
@@ -13,16 +13,16 @@ The fundamental unit in a manifest is the "item", which is a
 collection of label name/value pairs; each unit should correspond to
 exactly one artifact on disk. Some labels are of special interest to
 the sample test runner, such as those named ``language``, ``path``,
-``bin``, and ``region_tag``. These four are interpreted, respectively,
-as the programming language of the given artifact, the path to that
+``bin``, and ``sample``. These four are interpreted, respectively, as
+the programming language of the given artifact, the path to that
 artifact on disk, the binary used to execute the artifact (if the
-artifact is not itself executable), and the unique region tag by which
-to quickly identify the artifact for the given language. In
-particular, artifacts with the same ``region_tag`` but different
+artifact is not itself executable), and the unique sample identifier
+by which to quickly identify the artifact in any language. In
+particular, artifacts with the same ``sample`` but different
 ``language``\ s are taken to represent the same conceptual sample, but
 implemented in the different programming languages; this allows a test
-specification to refer to the ``region_tag``\ s only and the runner
-will then run that test for each of the ``language``\ s available.
+specification to refer to the ``sample``\ s only and the runner will
+then run that test for each of the ``language``\ s available.
 
 Since a lot of the artifacts will share part or all of some labels
 (for example, the initial directory components, or the binary used to

--- a/docs/invoking-tester/cli-reference.rst
+++ b/docs/invoking-tester/cli-reference.rst
@@ -49,8 +49,8 @@ to actual, specific files on disk for given languages and
 environments. Each convention may choose to take some set-up
 arguments. You can specify an alternate convention and/or convention
 arguments via the flag ``--convention=CONVENTION:ARG,ARGS``. The
-default convention is ``tag:region_tag``, which uses the
-``region_tag`` key in the manifest files. To use, say, the ``target``
+default convention is ``tag:sample``, which uses the
+``sample`` key in the manifest files. To use, say, the ``target``
 key in the manifest, simply pass ``--convention=tag:target``.
 
 If you want to define an additional convention, refer to the

--- a/examples/sample.manifest.yaml
+++ b/examples/sample.manifest.yaml
@@ -25,17 +25,17 @@ sets:       # a list of groupings
   bin: python3  # used to run these items
   __items__:
   - path: "trivial/method/sample_alice"
-    region_tag: "alice"
+    sample: "alice"
     canonical: "trivial"
   - path: "complex/method/usecase_bob"
-    region_tag: "robert"
+    sample: "robert"
     tag: "guide"
 - path: "/tmp/"
   __items__:
   - path: "newer/carol"
-    region_tag: "math"
+    sample: "math"
   - path: "newest/dan"
-    region_tag: "math"
+    sample: "math"
 # The above two groupings together are equivalent to the following
 # flattened grouping, which does not use any top-level labels. Note
 # that in a real application you would not specify an artifact twice
@@ -44,14 +44,14 @@ sets:       # a list of groupings
   - path: "/home/nobody/api/samples/trivial/method/sample_alice"
     environment: python
     bin: python3  # used to run this item
-    region_tag: "alice"
+    sample: "alice"
     canonical: "trivial"
   - path: "/home/nobody/api/samples/complex/method/usecase_bob"
     environment: python
     bin: python3  # used to run this item
-    region_tag: "robert"
+    sample: "robert"
     tag: "guide"
   - path: "/tmp/newer/carol"
-    region_tag: "math"
+    sample: "math"
   - path: "/tmp/newest/dan"
-    region_tag: "math"
+    sample: "math"

--- a/examples/sample.manifest.yaml
+++ b/examples/sample.manifest.yaml
@@ -20,7 +20,7 @@ sets:       # a list of groupings
 # prepended to the value specified in the item. The idea is that you
 # can specify repeated parts of a path up here, and only the parts
 # that vary in each item
-- language: python
+- environment: python
   path: "/home/nobody/api/samples/"
   bin: python3  # used to run these items
   __items__:
@@ -42,12 +42,12 @@ sets:       # a list of groupings
 # like we do here for illustrative purposes.
 - __items__:
   - path: "/home/nobody/api/samples/trivial/method/sample_alice"
-    language: python
+    environment: python
     bin: python3  # used to run this item
     region_tag: "alice"
     canonical: "trivial"
   - path: "/home/nobody/api/samples/complex/method/usecase_bob"
-    language: python
+    environment: python
     bin: python3  # used to run this item
     region_tag: "robert"
     tag: "guide"

--- a/sampletester/cli.py
+++ b/sampletester/cli.py
@@ -91,7 +91,8 @@ def main():
   quiet = verbosity == summary.Detail.NONE
   visitor = testplan.MultiVisitor(runner.Visitor(args.fail_fast),
                                   summary.SummaryVisitor(verbosity,
-                                                         not args.suppress_failures))
+                                                         not args.suppress_failures,
+                                                         debug=DEBUGME))
   try:
     success = manager.accept(visitor)
   except KeyboardInterrupt:

--- a/sampletester/convention/__init__.py
+++ b/sampletester/convention/__init__.py
@@ -16,7 +16,7 @@ import importlib
 import logging
 import os
 
-DEFAULT="tag:region_tag"
+DEFAULT="tag:sample"
 
 __abs_file__ = os.path.abspath(__file__)
 __abs_file_path__ = os.path.split(__abs_file__)[0]

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -59,7 +59,7 @@ class Manifest:
     self.interpreter = {'1': self.index_source_v1}
 
     # tags[key1][key2]...[keyn] == [metadata, metadata, ...]
-    # eg with self.indices == ["language", "region_tag"]:
+    # eg with self.indices == ["language", "sample"]:
     #    tags["python"]["analyze_sentiment"] = [ sentiment_john_meta, sentiment_mary_meta ]
     self.tags = {}
 

--- a/sampletester/summary.py
+++ b/sampletester/summary.py
@@ -33,12 +33,14 @@ class SummaryVisitor(testplan.Visitor):
   """
 
   def __init__(self, verbosity, show_errors,
-               progress_out=sys.stderr):
+               progress_out=sys.stderr,
+               debug=False):
     self.verbosity = verbosity
     self.show_errors = show_errors
     self.lines = []
     self.indent = '  '
     self.progress_out = progress_out if progress_out else os.devnull
+    self.debug = debug
 
   def visit_environment(self, environment: testplan.Environment, doit: bool):
     if self.verbosity == Detail.NONE and (environment.success() or not self.show_errors):
@@ -72,6 +74,9 @@ class SummaryVisitor(testplan.Visitor):
                       .format(status, name))
     if runner and (self.verbosity == Detail.FULL or (self.show_errors and not tcase.success())):
       self.append_lines(runner.get_output(6, '| '))
+    if self.debug and runner:
+      for error in runner.get_errors():
+        self.append_lines('DEBUGGING: Error "{}":\n{}'.format(error[0],error[1]))
 
   def output(self):
     return '\n'.join(self.lines)

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -23,14 +23,14 @@ class TestManifest(unittest.TestCase):
   def test_read_no_version(self):
     manifest_source = self.get_manifest_source()
     manifest_source[0][1].pop('version')
-    manifest = sample_manifest.Manifest('language', 'region_tag')
+    manifest = sample_manifest.Manifest('language', 'sample')
     with self.assertRaises(Exception):
       manifest.read_sources([manifest_source])
 
   def test_read_invalid_version(self):
     manifest_source = self.get_manifest_source()
     manifest_source[0][1]['version'] = 'foo'
-    manifest = sample_manifest.Manifest('language', 'region_tag')
+    manifest = sample_manifest.Manifest('language', 'sample')
     with self.assertRaises(Exception):
       manifest.read_sources(manifest_source)
 
@@ -38,7 +38,7 @@ class TestManifest(unittest.TestCase):
     manifest_source, expect_alice, expect_bob, expect_carol, expect_dan = self.get_manifest_source(
     )
 
-    manifest = sample_manifest.Manifest('language', 'region_tag')
+    manifest = sample_manifest.Manifest('language', 'sample')
     manifest.read_sources([manifest_source])
     manifest.index()
 
@@ -71,7 +71,7 @@ class TestManifest(unittest.TestCase):
     (manifest_source, expect_alice, expect_bob, expect_carol,
      expect_dan) = self.get_manifest_source()
 
-    manifest = sample_manifest.Manifest('language', 'region_tag')
+    manifest = sample_manifest.Manifest('language', 'sample')
     manifest.read_sources([manifest_source])
     manifest.index()
 
@@ -112,12 +112,12 @@ class TestManifest(unittest.TestCase):
                 sample_manifest.Manifest.ELEMENTS_KEY:
                     [{
                         'path': 'trivial/method/sample_alice',
-                        'region_tag': 'alice',
+                        'sample': 'alice',
                         'canonical': 'trivial'
                     },
                      {
                          'path': 'complex/method/usecase_bob',
-                         'region_tag': 'robert',
+                         'sample': 'robert',
                          'tag': 'guide'
                      }]
             },
@@ -126,10 +126,10 @@ class TestManifest(unittest.TestCase):
                      '/tmp/',
                  sample_manifest.Manifest.ELEMENTS_KEY: [{
                      'path': 'newer/carol',
-                     'region_tag': 'math'
+                     'sample': 'math'
                  }, {
                      'path': 'newest/dan',
-                     'region_tag': 'math'
+                     'sample': 'math'
                  }]
              }]
     }
@@ -137,17 +137,17 @@ class TestManifest(unittest.TestCase):
     expect_alice = {
         'path': '/home/nobody/api/samples/trivial/method/sample_alice',
         'language': 'python',
-        'region_tag': 'alice',
+        'sample': 'alice',
         'canonical': 'trivial'
     }
     expect_bob = {
         'path': '/home/nobody/api/samples/complex/method/usecase_bob',
         'language': 'python',
-        'region_tag': 'robert',
+        'sample': 'robert',
         'tag': 'guide'
     }
-    expect_carol = {'path': '/tmp/newer/carol', 'region_tag': 'math'}
-    expect_dan = {'path': '/tmp/newest/dan', 'region_tag': 'math'}
+    expect_carol = {'path': '/tmp/newer/carol', 'sample': 'math'}
+    expect_dan = {'path': '/tmp/newest/dan', 'sample': 'math'}
     return ('valid_manifest',
             manifest), expect_alice, expect_bob, expect_carol, expect_dan
 

--- a/tests/testdata/caserunner_test.manifest.yaml
+++ b/tests/testdata/caserunner_test.manifest.yaml
@@ -17,6 +17,6 @@ sets:
 - language: shell
   __items__:
   - path: "/bin/echo"
-    region_tag: "output"
+    sample: "output"
   - path: "/none/wibble"
-    region_tag: "wibble"
+    sample: "wibble"


### PR DESCRIPTION
This changes the tag convention to use `environment` instead of `language`.

It also changes the default parameter for the convention to use `sample` instead of `region_tag`
