### PR TITLE
Tag v0.9.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ The sample tester allows defining tests once and applying them to
 semantically identical executables (typically runnable code samples)
 instantiated in multiple languages and environments.
 
-Version: 0.8.1
+Version: 0.9.0
 
 **PRE-RELEASE**: This surface is not guaranteed to be stable. Breaking changes will still occur.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Google LLC'
 author = 'Victor Chudnovsky'
 
 # The short X.Y version
-version = '0.8.1'
+version = '0.9.0'
 # The full version, including alpha/beta/rc tags
-release = '0.8.1'
+release = '0.9.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/defining-tests/testplan-reference.rst
+++ b/docs/defining-tests/testplan-reference.rst
@@ -40,6 +40,7 @@ how to run the samples and what checks to perform.
      a ``call``, it must have succeeded so this assertion will fail.
    - ``env``: assign the value of an environment variable to a
      test case variable
+   - ``extract_match``: extrack regex matches into local variables
    - ``code``: execute the argument as a chunk of Python code. The
      other directives above are available as Python calls with the
      names above. In addition, the following functions are available

--- a/sampletester/cli.py
+++ b/sampletester/cli.py
@@ -45,7 +45,7 @@ from sampletester import summary
 from sampletester import testplan
 from sampletester import xunit
 
-VERSION = '0.8.1'
+VERSION = '0.9.0'
 EXITCODE_SUCCESS = 0
 EXITCODE_TEST_FAILURE = 1
 EXITCODE_FLAG_ERROR = 2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 setup(
     name='sample-tester',
-    version='0.8.1',
+    version='0.9.0',
 
     license='Apache 2.0',
     author='Victor Chudnovsky',


### PR DESCRIPTION
Functional changes:
* **SEMANTIC CHANGE**: change tag convention to use `environment` and `sample` (#31)
* implement `extract_match` to retrieve regexps from call output (#27)

Other changes:
* stricter semantics on `call` vs `shell` (#25 #29)
* make `_last_case_output` available via yaml and code (#30)
* print failing suite name (#26)
* assorted clean-ups
