### PR TITLE
In test plan files, s/target:/sample:/

### DIFF
--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -27,7 +27,7 @@ test:
     - name: "A test defined via yaml directives"
       spec:
       - call:
-          target: "language_analyze_sentiment_text"
+          sample: "language_analyze_sentiment_text"
           params:
             content:
               literal: "happy happy smile hope"

--- a/examples/convention-cloud/product_search_test.yaml
+++ b/examples/convention-cloud/product_search_test.yaml
@@ -24,7 +24,7 @@ test:
         log("Product ID for this test suite is {}", product_id)
     teardown:
     - call_may_fail:
-        target: "examples/testdata/samples/vision/product-search/delete_product.py  "
+        sample: "examples/testdata/samples/vision/product-search/delete_product.py  "
         args:
         - variable: product_id
     - code: |
@@ -32,26 +32,26 @@ test:
     - name: Product Life
       spec:
       - call:
-          target: "examples/testdata/samples/vision/product-search/list_products.py"
+          sample: "examples/testdata/samples/vision/product-search/list_products.py"
       - assert_not_contains:
           - variable: product_id
       - call:
-          target: "examples/testdata/samples/vision/product-search/create_product.py"
+          sample: "examples/testdata/samples/vision/product-search/create_product.py"
           args:
           - variable: product_id
           - literal: Fancier towel
           - literal: homegoods
       - call:
-          target: "examples/testdata/samples/vision/product-search/list_products.py"
+          sample: "examples/testdata/samples/vision/product-search/list_products.py"
       - assert_contains:
           - variable: product_id
           - literal: "towel"
       - call:
-          target: "examples/testdata/samples/vision/product-search/delete_product.py"
+          sample: "examples/testdata/samples/vision/product-search/delete_product.py"
           args:
           - variable: product_id
       - call:
-          target: "examples/testdata/samples/vision/product-search/list_products.py"
+          sample: "examples/testdata/samples/vision/product-search/list_products.py"
       - assert_not_contains:
           - variable: product_id
 

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -420,7 +420,7 @@ class TestCase:
     return parts[key_variable], parts[key_what]
 
   def params_for_call(self, parts):
-    key_cmd = "target"
+    key_cmd = "sample"
     key_params = "params"
     key_args = "args"
     if len(parts) < 1 or not key_cmd in parts:

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -62,7 +62,7 @@ test:
         - literal: "worst"
           
       - call:
-          target: 'output'
+          sample: 'output'
           args:
             - literal: "Greetings"
       - assert_success:
@@ -80,7 +80,7 @@ test:
         - message: "foobar call should have failed"
         
       - call_may_fail:
-          target: 'wibble'
+          sample: 'wibble'
       - assert_failure:
         - message: "wibble call should have failed"
         
@@ -114,7 +114,7 @@ test:
     - name: yaml
       spec:
       - call:
-          target: 'wibble'
+          sample: 'wibble'
   - name: Failing assert_success
     cases:
     - name: code


### PR DESCRIPTION
This addresses partially #34 by hardcoding the change. In a future PR, we'll make this configurable.