### PR TITLE
Get the `target` field name from the tag convention parameter

### DIFF
--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -420,7 +420,7 @@ class TestCase:
     return parts[key_variable], parts[key_what]
 
   def params_for_call(self, parts):
-    key_cmd = "sample"
+    key_cmd = self.environment.get_testcase_settings().get('call.target', 'target')
     key_params = "params"
     key_args = "args"
     if len(parts) < 1 or not key_cmd in parts:

--- a/sampletester/convention/__init__.py
+++ b/sampletester/convention/__init__.py
@@ -21,11 +21,18 @@ DEFAULT="tag:sample"
 __abs_file__ = os.path.abspath(__file__)
 __abs_file_path__ = os.path.split(__abs_file__)[0]
 
+# The list of environment creation functions for each of the various conventions
+# we discover below.
+environment_creators = {}
+
+# We find all the conventions defined via modules and subpackages rooted in the
+# current directory
 all_files = [entry for entry in os.listdir(__abs_file_path__)
              if entry !='__init__.py' and entry != '__pycache__' and not entry.endswith('~')]
 all_conventions = [os.path.splitext(os.path.basename(entry))[0] for entry in all_files]
-environment_creators = {}
 
+# We register the environment creation function for each convention. Each such
+# function has the name `test_environments` within the convention code.
 for convention in all_conventions:
   module = importlib.import_module('.'+convention, package='sampletester.convention')
   if 'test_environments' in dir(module):
@@ -33,6 +40,18 @@ for convention in all_conventions:
     environment_creators[convention] = module.test_environments
 
 def generate_environments(requested_conventions, convention_args, files):
+  """Generates the environments for the requested conventions with the given args.
+
+  Note that a given convention may (and usually will) generate multiple
+  environments, typically for running tests in multiple languages.
+
+  Args:
+    requested_conventions: A list of strings, each of which contains the
+       name of a convention previously registered in `environment_creators`
+    convention_args: A list of args to pass in its entirety to each convention
+       in `requested_conventions`
+    files: A list of files needed by the convention to instantiate environments.
+  """
   all_environments = []
   for convention in requested_conventions:
     create_fn = environment_creators.get(convention, None)
@@ -41,5 +60,7 @@ def generate_environments(requested_conventions, convention_args, files):
     try:
       all_environments.extend(create_fn(files, convention_args))
     except Exception as ex:
-      raise ValueError('could not create test environments for convention "{}": {}'.format(convention, repr(ex)))
+      raise ValueError(
+          'could not create test environments for convention "{}": {}'
+          .format(convention, repr(ex)))
   return all_environments

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -23,10 +23,14 @@ class Manifest:
   """Maintains a manifest of auto-generated sample artifacts.
 
   A manifest is a list of artifacts (read from one or more external sources,
-  such as files or arrays). Each artifact on the list is associated with any
-  number of labels. An artifact can be any value, but in our application is a
-  filepath to a sample. It is possible for more than one artifact to share the
-  same set of labels.
+  such as files or arrays). Each artifact on the list is, for the purposes of
+  the manifest, simply a set of labels. A Manifest object knows nothing of the
+  semantics of how it is used, but as an illustration, in sample-tester use
+  cases, the following typically hold:
+    - One of the labels for an artifact is the path to a sample on disk.
+    - It is possible for more than one artifact to share the same set of labels,
+      though typically some of the labels will be unique per artifact (eg sample
+      ID, sample file path).
 
   A label contains a "label name" (a name of some category) and a "label value"
   (the value within that category). Neither values nor names need to be

--- a/sampletester/testenv.py
+++ b/sampletester/testenv.py
@@ -34,6 +34,10 @@ class Base:
     logging.fatal(
         'get_call() invoked on Base (should be overridden)')
 
+  def get_testcase_settings(self):
+    """Returns testenv parameters to be used by the test runner"""
+    return {}
+
 
 def process_args(*args, **kwargs):
   """returns a pair (artifact name, arg invocation)"""

--- a/sampletester/testplan.py
+++ b/sampletester/testplan.py
@@ -224,7 +224,7 @@ CASE_NAME = "name"
 CASE_SPEC = "spec"
 
 class Manager:
-
+  """Hosts Visitors to a Wrapper hierarchy"""
   def __init__(self, environment_registry, test_suites, env_filter:str = None):
     self.test_suites = test_suites
 
@@ -264,6 +264,10 @@ class Manager:
 
 
 def suite_configs_from(test_files):
+  """Returns the suite configs (key/value pairs) from all the `test_files`.
+
+  Helper function for suites_from(), which is what most clients will want to call.
+  """
 
   # TODO(vchudnov): Append line number info to aid in error messages
   # cf: https://stackoverflow.com/a/13319530
@@ -280,8 +284,13 @@ def suite_configs_from(test_files):
 
 
 def suite_objects_from(all_suites, suite_filter = None, case_filter = None):
+  """Creates Suite objects from the given suite config key/value specs.
+
+  Helper function for suites_from(), which is what most clients will want to call.
+  """
   return [Suite(spec, suite_filter, case_filter) for spec in all_suites]
 
 
 def suites_from(test_files, suite_filter = None, case_filter = None):
+  """Creates Suite objects from the given YAML test_files"""
   return suite_objects_from(suite_configs_from(test_files), suite_filter, case_filter)

--- a/tests/testdata/caserunner_test_target.manifest.yaml
+++ b/tests/testdata/caserunner_test_target.manifest.yaml
@@ -14,9 +14,7 @@
 
 version: 1
 sets:
-- environment: shell
+- environment: alps
   __items__:
-  - path: "/bin/echo"
-    sample: "output"
-  - path: "/none/wibble"
-    sample: "wibble"
+  - path: "/bin/echo 'called echo'"
+    alpine: "output"

--- a/tests/testdata/caserunner_test_target.yaml
+++ b/tests/testdata/caserunner_test_target.yaml
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 1
-sets:
-- environment: shell
-  __items__:
-  - path: "/bin/echo"
-    sample: "output"
-  - path: "/none/wibble"
-    sample: "wibble"
+test:
+  suites:
+  - name: Failing call
+    cases:
+    - name: code
+      spec:
+      - code: out=call('output')


### PR DESCRIPTION
Fixes #34 

- includes tests
- adds implementation comments in a bunch of places