### PR TITLE
Manifest schema 2: tag inclusion

### DIFF
--- a/docs/defining-tests/manifest-reference.rst
+++ b/docs/defining-tests/manifest-reference.rst
@@ -1,43 +1,67 @@
 .. _defining-tests/manifest-reference:
 
-Manifest
+Manifest file format
 --------
 
 A manifest file is a YAML file that associates each artifact (sample)
 of interest on disk with a series of tags that can be used to uniquely
-identify that artifact. Right now only version "1" of the manifest
-file format is supported, but we have the version as the first field
-in the file to support different schemas in the future.
+identify that artifact. Right now both versions "1" and "2" of the
+manifest file format are supported; version "2" is a superset of version "1".
 
 The fundamental unit in a manifest is the "item", which is a
-collection of label name/value pairs; each unit should correspond to
-exactly one artifact on disk. Some labels are of special interest to
-the sample test runner, such as those named ``language``, ``path``,
-``bin``, and ``sample``. These four are interpreted, respectively, as
-the programming language of the given artifact, the path to that
-artifact on disk, the binary used to execute the artifact (if the
-artifact is not itself executable), and the unique sample identifier
-by which to quickly identify the artifact in any language. In
-particular, artifacts with the same ``sample`` but different
-``language``\ s are taken to represent the same conceptual sample, but
-implemented in the different programming languages; this allows a test
-specification to refer to the ``sample``\ s only and the runner will
-then run that test for each of the ``language``\ s available.
+collection of tag name/value pairs; each unit should correspond to
+exactly one artifact on disk. 
 
-Since a lot of the artifacts will share part or all of some labels
+Since a lot of the artifacts will share part or all of some tags
 (for example, the initial directory components, or the binary used to
 execute them), "items" are grouped into "sets". Each set may define
-its own label name/value pairs. These pairs are applied to each of the
+its own tag name/value pairs. These pairs are applied to each of the
 items inside the set as follows:
 
-#. If the item does not define a given label name, then the label
+#. If the item does not define a given tag name, then the tag
    name/value pair in its set is applied to the item.
-#. If the item does define a given label name, then the corresponding
-   label value specified in the set is prepended to the corresponding
+#. If the item does define a given tag name, then the corresponding
+   tag value specified in the set is prepended to the corresponding
    value specified in the item. This is particularly useful in the
    case of paths: the set may define the common path for all of its
    items, and each item specifies its unique trailing directories and
    filename.
+
+In manifest version "2", tag values can include references to other
+tags: the value of tag “A” can reference the value of tag “B” by
+enclosing the name of tag “B” in curly brackets: ``{TAG_B_NAME}``. For
+example:
+
+.. code-block:: yaml
+		
+   name: Zoe
+   greeting: "Hello, {name}!
+   
+will define the same sets of tags as
+
+.. code-block:: yaml
+
+   name: Zoe
+   greeting: "Hello, Zoe!"
+
+While tags can be referenced arbitrarily deep, no reference can form a loop (ie a tag directly or indirectly including itself).
+
+Tags for sample-tester
+----
+
+Some manifest tags are of special interest to the sample test runner,
+such as those named ``environment``, ``path``, ``bin``, and
+``sample``. These four are interpreted, respectively, as the
+programming language of the given artifact, the path to that artifact
+on disk, the binary used to execute the artifact (if the artifact is
+not itself executable), and the unique sample identifier by which to
+quickly identify the artifact in any language. In particular,
+artifacts with the same ``sample`` but different ``environment``\ s
+are taken to represent the same conceptual sample, but implemented in
+the different programming languages or execution environments; this
+allows a test specification to refer to the ``sample``\ s only and the
+runner will then run that test for each of the ``emvironment``\ s
+available.
 
 .. literalinclude:: language.manifest.yaml
    :start-after: Example manifest file

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -60,7 +60,10 @@ class Manifest:
       indices: An optional list of labels by which to index the manifest read in
         from various sources
     """
-    self.interpreter = {'1': self.index_source_v1}
+    self.interpreter = {
+        '1': self.index_source_v1,
+        '2': self.index_source_v1,  #  TODO: change to v2 once coded
+    }
 
     # tags[key1][key2]...[keyn] == [metadata, metadata, ...]
     # eg with self.indices == ["language", "sample"]:

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -141,17 +141,19 @@ class Manifest:
 
     for sample_set in input.get(self.SETS_KEY):
 
-      # get the tag defaults/prefixes for this set
-      set_values = sample_set.copy()
-      set_values.pop(self.ELEMENTS_KEY, None)
+      # Get the tag defaults/prefixes for this set
+      set_common_values = sample_set.copy()
+      set_common_values.pop(self.ELEMENTS_KEY, None)
 
       all_elements = sample_set.get(self.ELEMENTS_KEY, [])
       for element in all_elements:
-        # add the needed defaults/prefixes to this element
-        for key, value in set_values.items():
-          element[key] = value + element.get(key, '')
+        # Add the needed defaults/prefixes to this element
+        for key, common_value in set_common_values.items():
+          element[key] = common_value + element.get(key, '')
 
-        # store
+        # Now store the element
+        # First resolve all the indices, so that we end up with tag referring to the
+        # non-index list
         tags = self.tags
         for idx_num, idx_key in enumerate(self.indices):
           idx_value = element.get(idx_key, '')

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -161,10 +161,31 @@ class Manifest:
         for idx_num, idx_key in enumerate(self.indices):
           idx_value = element.get(idx_key, '')
           tags = get_or_create(tags, idx_value,
-                               [] if idx_num == max_idx else {})
+                               [] if idx_num >= max_idx else {})
         tags.append(element)
 
         logging.info('read "{}"'.format(element))
+
+
+  def get_all_elements(self):
+    """Generators that yields each element in the manifest."""
+    yield from self._get_element(self.tags, idx_num = 0)
+
+  def _get_element(self, tags, idx_num):
+    """Recursive helper function for get_all_elements.
+
+    Traverses each index level to retrieve each list item individually.
+    """
+    idx_end = len(self.indices)
+    if idx_num >= idx_end:
+      # base case: we're done with indices, so just yield all the elements in the non-index list
+      for element in tags:
+        yield element
+      return
+
+    # recurse to the next index level
+    for key, subtag  in tags.items():
+      yield from self._get_element(subtag, idx_num+1)
 
   #TODO: add test
   def get_keys(self, *specified_keys):

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -171,8 +171,9 @@ class TestManifest(unittest.TestCase):
             version,
         sample_manifest.Manifest.SETS_KEY:
             [{
-                'greetings': 'teatime',
-                'form': 'Would you like some {drink}?',
+                'greetings': 'teatime-{name}{{',
+                'fond_wish': 'hope{{',
+                'form': 'Would you like some {drink}? {{maybe}}',
                 'drink': 'tea',
                 sample_manifest.Manifest.ELEMENTS_KEY:
                     [{
@@ -192,13 +193,14 @@ class TestManifest(unittest.TestCase):
 
     expect_mary = {
         'name': 'Mary',
-        'greetings': 'teatime',
-        'form': 'Would you like some {drink}?',
+        'fond_wish': 'hope{{',
+        'greetings': 'teatime-{name}{{',
+        'form': 'Would you like some {drink}? {{maybe}}',
         'drink': 'tea with milk',
         'interruption': 'Excuse me, {name}. {form}'
     }
 
-    self.assertEqual(expect_mary, manifest.get_one('teatime', name='Mary'))
+    self.assertEqual(expect_mary, manifest.get_one('teatime-{name}{{', name='Mary'))
 
   def test_braces_v2(self):
     manifest_source = self.get_manifest_source_braces_correct(2)
@@ -208,13 +210,117 @@ class TestManifest(unittest.TestCase):
 
     expect_mary = {
         'name': 'Mary',
-        'greetings': 'teatime',
-        'form': 'Would you like some tea with milk?',
+        'fond_wish': 'hope{',
+        'greetings': 'teatime-Mary{',
+        'form': 'Would you like some tea with milk? {maybe}',
         'drink': 'tea with milk',
-        'interruption': 'Excuse me, Mary. Would you like some tea with milk?'
+        'interruption': 'Excuse me, Mary. Would you like some tea with milk? {maybe}'
     }
 
-    self.assertEqual(expect_mary, manifest.get_one('teatime', name='Mary'))
+    self.assertEqual(expect_mary, manifest.get_one('teatime-Mary{', name='Mary'))
+
+
+  def test_braces_error_unfinished(self):
+    manifest_content = {
+        sample_manifest.Manifest.VERSION_KEY: 2,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': 'teatime',
+                'form': 'Would you like some {drink?', # error
+                'drink': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([('erroring manifest', manifest_content)])
+    self.assertRaises(sample_manifest.SyntaxError, manifest.index)
+
+  def test_braces_error_unfinished_at_end(self):
+    manifest_content = {
+        sample_manifest.Manifest.VERSION_KEY: 2,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': 'teatime',
+                'form': 'Would you like some {', # error
+                'drink': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([('erroring manifest', manifest_content)])
+    self.assertRaises(sample_manifest.SyntaxError, manifest.index)
+
+  def test_braces_error_empty(self):
+    manifest_content = {
+        sample_manifest.Manifest.VERSION_KEY: 2,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': 'teatime',
+                'form': 'Would you like some {}?', # error
+                'drink': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([('erroring manifest', manifest_content)])
+    self.assertRaises(sample_manifest.SyntaxError, manifest.index)
+
+  def test_braces_error_key_with_braces(self):
+    manifest_content = {
+        sample_manifest.Manifest.VERSION_KEY: 2,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': 'teatime',
+                'form': 'Would you like some {drink{yea}}}?', # error
+                'drink{yea}}': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([('erroring manifest', manifest_content)])
+    self.assertRaises(sample_manifest.SyntaxError, manifest.index)
+
+  def test_braces_error_loop(self):
+    manifest_content = {
+        sample_manifest.Manifest.VERSION_KEY: 2,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': '{drink} time',
+                'form': 'It is {greetings}. Would you like some {drink}?',
+                'drink': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'greetings': ' {form}', # cycle
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([('erroring manifest', manifest_content)])
+    self.assertRaises(sample_manifest.CycleError, manifest.index)
+
 
 
 if __name__ == '__main__':

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -99,6 +99,19 @@ class TestManifest(unittest.TestCase):
 
     self.assertIsNone(manifest.get_one('', 'math'))
 
+  def test_get_all_elements(self):
+    (manifest_source, expect_alice, expect_bob, expect_carol,
+     expect_dan) = self.get_manifest_source()
+
+    manifest = sample_manifest.Manifest('language', 'sample')
+    manifest.read_sources([manifest_source])
+    manifest.index()
+
+    all_elements = [x for x in manifest.get_all_elements()]
+    self.assertEqual([expect_alice, expect_bob, expect_carol, expect_dan],
+                     all_elements)
+
+
   def get_manifest_source(self):
     manifest = {
         sample_manifest.Manifest.VERSION_KEY:

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -187,6 +187,22 @@ class TestManifest(unittest.TestCase):
 
     self.assertEqual(expect_mary, manifest.get_one('teatime', name='Mary'))
 
+  def test_braces_v2(self):
+    manifest_source = self.get_manifest_source_braces_correct(2)
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([manifest_source])
+    manifest.index()
+
+    expect_mary = {
+        'name': 'Mary',
+        'greetings': 'teatime',
+        'form': 'Would you like some tea with milk?',
+        'drink': 'tea with milk',
+        'interruption': 'Excuse me, Mary. Would you like some tea with milk?'
+    }
+
+    self.assertEqual(expect_mary, manifest.get_one('teatime', name='Mary'))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -152,5 +152,41 @@ class TestManifest(unittest.TestCase):
             manifest), expect_alice, expect_bob, expect_carol, expect_dan
 
 
+  def get_manifest_source_braces_correct(self, version):
+    manifest = {
+        sample_manifest.Manifest.VERSION_KEY:
+            version,
+        sample_manifest.Manifest.SETS_KEY:
+            [{
+                'greetings': 'teatime',
+                'form': 'Would you like some {drink}?',
+                'drink': 'tea',
+                sample_manifest.Manifest.ELEMENTS_KEY:
+                    [{
+                        'name': 'Mary',
+                        'drink': ' with milk',
+                        'interruption': 'Excuse me, {name}. {form}'
+                    }]
+                }]
+        }
+    return ('manifest with braces', manifest)
+
+  def test_braces_v1(self):
+    manifest_source = self.get_manifest_source_braces_correct(1)
+    manifest = sample_manifest.Manifest('greetings')
+    manifest.read_sources([manifest_source])
+    manifest.index()
+
+    expect_mary = {
+        'name': 'Mary',
+        'greetings': 'teatime',
+        'form': 'Would you like some {drink}?',
+        'drink': 'tea with milk',
+        'interruption': 'Excuse me, {name}. {form}'
+    }
+
+    self.assertEqual(expect_mary, manifest.get_one('teatime', name='Mary'))
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This implements tag inclusion: the value of one tag can include the value of another by referencing the latter's key via `{ }`

Includes tests and updates to doc.
