### PR TITLE
Be more explicit about case-insensitive contains

### DIFF
--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -243,27 +243,27 @@ class TestCase:
     return out
 
   # Expectation on the output of the last call.
-  def expect_contains(self, message, *values):
+  def expect_contains(self, message, *values, **kwargs):
     self._contain_check(
-        self.expect, lambda substr: self.last_output_contains(substr), message,
+        self.expect, lambda substr: self.last_output_contains(substr, **kwargs), message,
         values)
 
   # Requirement on the output of the last call.
-  def assert_contains(self, message, *values):
+  def assert_contains(self, message, *values, **kwargs):
     self._contain_check(
-        self.assert_that, lambda substr: self.last_output_contains(substr),
+        self.assert_that, lambda substr: self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Negative expectation on the output of the last call.
-  def expect_not_contains(self, message, *values):
+  def expect_not_contains(self, message, *values, **kwargs):
     self._contain_check(
-        self.expect, lambda substr: not self.last_output_contains(substr),
+        self.expect, lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Negative assertion on the output of the last call.
-  def assert_not_contains(self, message, *values):
+  def assert_not_contains(self, message, *values, **kwargs):
     self._contain_check(
-        self.assert_that, lambda substr: not self.last_output_contains(substr),
+        self.assert_that, lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Assertion on the return value of the last call indicating success.
@@ -374,7 +374,10 @@ class TestCase:
 
   #### Helper methods
 
-  def last_output_contains(self, substr):
+  def last_output_contains(self, substr, **kwargs):
+    case_sensitive = kwargs.get('case_sensitive', False)
+    if case_sensitive:
+      return substr in self.last_call_output
     return substr.lower() in self.last_call_output.lower()
 
   def format_string(self, msg, *args):
@@ -456,7 +459,9 @@ class TestCase:
     return [cmd] + args, params
 
   def params_for_contains(self, parts):
-    return self.string_and_params("message", parts), {}
+    # TODO: Allow case-sensitive matching as well, once we figure out the format
+    # in the YAML.
+    return self.string_and_params("message", parts), {'case_sensitive': False}
 
   def string_and_params(self, name: str, parts, *, strict: bool = False):
     if name in parts[0]:

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -25,8 +25,8 @@ test:
       - code: |
           _, out = shell('/bin/echo', '"It was the best of times"')
           assert_success("echo should have succeeded")
-          assert_contains("BEST")
-          assert_not_contains("worst")
+          assert_contains("BeSt")
+          assert_not_contains("wOrSt")
           assert_that('ime' in out, 'expected "ime" in the preceding output')
           expect('ime' in out, 'expected "ime" in the preceding output')
           assert_that('ime' in _last_call_output, 'expected "ime" in the preceding output')
@@ -56,10 +56,10 @@ test:
         - "echo should have succeeded"
       - assert_contains:
         - message: "Expected 'best'"
-        - literal: "BEST"
+        - literal: "bEsT"
       - assert_not_contains:
         - message: "Expected no 'worst'"            
-        - literal: "worst"
+        - literal: "wOrSt"
           
       - call:
           sample: 'output'

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -23,7 +23,7 @@ test:
     - name: "code"
       spec:
       - code: |
-          _, out = shell('/bin/echo', '"It was the best of times"')
+          _, out = shell('/bin/echo', '"It was the bEsT of times"')
           assert_success("echo should have succeeded")
           assert_contains("BeSt")
           assert_not_contains("wOrSt")
@@ -51,11 +51,11 @@ test:
       spec:
       - shell:
           - "/bin/echo"
-          - "It was the best of times"
+          - "It was the beSt of times"
       - assert_success:
         - "echo should have succeeded"
       - assert_contains:
-        - message: "Expected 'best'"
+        - message: "Expected 'bEsT' to match"
         - literal: "bEsT"
       - assert_not_contains:
         - message: "Expected no 'worst'"            


### PR DESCRIPTION
- This tweaks the tests to make the case-insensitive matching more obvious
- This makes it clear where we'll need to modify code to implement case-sensitive contains in the future