### PR TITLE
Implement assert_contains_any and related checks

### DIFF
--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -60,7 +60,7 @@ test:
           magnitude = float(magnitude_found.group(1))
           assert_that(magnitude > 0.7, 'magnitude is high')
 
-          assert_not_contains("random message", "the rain in Spain")
+          assert_not_contains("the rain in Spain", message="random message")
           
     - name: "A test defined via 'code', with explicit calls to specific samples"
       spec:

--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -33,6 +33,14 @@ test:
               literal: "happy happy smile hope"
       - assert_success: [] # try assert_failure to see how failure looks
       - assert_contains:
+          - message: "Have score and magnitude"
+          - literal: "score"
+          - literal: "magnitude"
+      - assert_contains_any:
+          - message: "Have magnitude or strength"
+          - literal: "strength"
+          - literal: "magnitude"
+      - assert_contains:
           - message: "Score is very positive"
           - literal: "score: 0.8"
       - assert_contains:
@@ -48,6 +56,10 @@ test:
       - code: |
           out = call("language_analyze_sentiment_text", content="happy happy smile hope")
           assert_success("that should have worked", "well")
+
+          assert_contains('score', 'magnitude', message='Have both score and magnitude')
+          assert_contains_any('strength', 'magnitude', message='Have either strength or magnitude')
+          
           import re
 
           score_found = re.search('score: ([0123456789.]+)', out) 

--- a/docs/defining-tests/testplan-reference.rst
+++ b/docs/defining-tests/testplan-reference.rst
@@ -26,10 +26,18 @@ how to run the samples and what checks to perform.
      call fails
    - ``call_may_fail``: call the artifact named in the argument; do
      not error even if the call fails
-   - ``assert_contains``: require the given variable to contain a
-     string (case-insensitively); abort the test case otherwise
-   - ``assert_not_contains``: require the given variable to not
-     contain a string (case-insensitively); abort the test case otherwise
+   - ``assert_contains``: require the output of the last ``call*`` to
+     contain all of the strings provided (case-insensitively); abort
+     the test case otherwise
+   - ``assert_not_contains``: require the output of the last ``call*``
+     to not contain any of the strings provided (case-insensitively);
+     abort the test case otherwise
+   - ``assert_contains_any``: require the output of the last ``call*``
+     to contain at least one of the strings provided
+     (case-insensitively); abort the test case otherwise
+   - ``assert_not_contains_some``: require the output of the last
+     ``call*`` to not contain at least one of the strings provided
+     (case-insensitively); abort the test case otherwise
    - ``assert_success``: require that the exit code of the last
      ``call_may_fail`` was 0; abort the test case otherwise. If the
      preceding call was a just a ``call``, it would have already

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -249,54 +249,102 @@ class TestCase:
     return out
 
   # Requirement on the output of the last call: at least one of the values is contained.
-  def assert_contains_any(self, message, *values, **kwargs):
+  def assert_contains_any(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.assert_that, any,
         lambda substr: self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Expectation on the output of the last call: at least one of the values is contained.
-  def expect_contains_any(self, message, *values, **kwargs):
+  def expect_contains_any(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.expect, any,
         lambda substr: self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Requirement on the output of the last call: at least one of the values is NOT contained.
-  def assert_not_contains_some(self, message, *values, **kwargs):
+  def assert_not_contains_some(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.assert_that, any,
         lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Expectation on the output of the last call: at least one of the values is NOT contained.
-  def expect_not_contains_some(self, message, *values, **kwargs):
+  def expect_not_contains_some(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.expect, any,
         lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Expectation on the output of the last call: each of the values is contained.
-  def expect_contains_all(self, message, *values, **kwargs):
+  def expect_contains_all(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.expect, all,
         lambda substr: self.last_output_contains(substr, **kwargs), message,
         values)
 
   # Requirement on the output of the last call: each of the values is contained.
-  def assert_contains_all(self, message, *values, **kwargs):
+  def assert_contains_all(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.assert_that, all, lambda substr: self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Negative expectation on the output of the last call: each of the values is NOT contained.
-  def expect_not_contains_any(self, message, *values, **kwargs):
+  def expect_not_contains_any(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.expect, all, lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
 
   # Negative assertion on the output of the last call: each of the values is NOT contained.
-  def assert_not_contains_any(self, message, *values, **kwargs):
+  def assert_not_contains_any(self, *values, **kwargs):
+    MSG='message'
+    message = ''
+
+    if MSG in kwargs:
+      message = kwargs[MSG]
+      del(kwargs[MSG])
     self._check_several(
         self.assert_that, all, lambda substr: not self.last_output_contains(substr, **kwargs),
         message, values)
@@ -510,20 +558,21 @@ class TestCase:
   def params_for_contains(self, parts):
     # TODO: Allow case-sensitive matching as well, once we figure out the format
     # in the YAML.
-    return self.string_and_params("message", parts), {'case_sensitive': False}
+    params, message = self.string_and_params("message", parts)
+    return params, {'case_sensitive': False, 'message': message}
 
-  def string_and_params(self, name: str, parts, *, strict: bool = False):
-    if name in parts[0]:
-      params = [parts[0][name]]
+  def string_and_params(self, name_label: str, parts, *, strict: bool = False):
+    if name_label in parts[0]:
+      name_value = parts[0][name_label]
       start = 1
     else:
       if strict:
         log_raise(logging.critical, ValueError,
-                  'expected field "{}"'.format(name))
-      params = [""]
+                  'expected field "{}"'.format(name_label))
+      name_value = ''
       start = 0
-    params.extend(self.get_yaml_values(parts[start:]))
-    return params
+    params = self.get_yaml_values(parts[start:])
+    return params, name_value
 
   def get_yaml_values(self, list):
     """Gets values from the `list` of maps, each map containing at most the keys "variable" or "literal".

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -25,18 +25,18 @@ test:
       - code: |
           _, out = shell('/bin/echo', '"It was the bEsT of times"')
           assert_success("echo should have succeeded")
-          assert_contains('', "BeSt")
-          assert_not_contains('', "wOrSt")
-          assert_contains_any('', 'commonest', 'best', 'worst')
-          assert_not_contains_some('', 'best', 'worst')
+          assert_contains("BeSt")
+          assert_not_contains("wOrSt")
+          assert_contains_any('commonest', 'best', 'worst')
+          assert_not_contains_some('best', 'worst')
           assert_that('ime' in out, 'expected "ime" in the preceding output')
           expect('ime' in out, 'expected "ime" in the preceding output')
           assert_that('ime' in _last_call_output, 'expected "ime" in the preceding output')
 
           call('output', 'Greetings')
           assert_success("call should have succeeded")
-          assert_contains('', "ree")
-          assert_not_contains('', "farewell")
+          assert_contains("ree")
+          assert_not_contains("farewell")
           assert_that('eti' in _last_call_output, 'expected "eti" in the preceding output')
 
           shell('/nonexistent/dir/foobar')
@@ -155,12 +155,12 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_contains('claim this is in there', 'worst')  # TODO: reverse these args; they're counterintuitive
+          assert_contains('worst', message='claim this is in there vmessage')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
       - assert_contains:
-        - message: "claim this is in there"
+        - message: "claim this is in there wmsg"
         - literal: "worst"
   - name: Failing assert_contains, multiple args
     cases:
@@ -168,7 +168,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_contains('claim this is in there', 'best', 'of', 'all')
+          assert_contains('best', 'of', 'all', message='claim this is in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -183,7 +183,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_contains_any('claim this is in there', 'worst', 'time', 'ever')
+          assert_contains_any('worst', 'time', 'ever', message='claim this is in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -198,7 +198,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_contains_any('claim this is in there', 'worst', 'epoch', 'ever')
+          assert_contains_any('worst', 'epoch', 'ever', message='claim this is in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -213,7 +213,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains('claim this is not in there', 'best')
+          assert_not_contains('best', message='claim this is not in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -226,7 +226,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains('claim this is not in there', 'worst', 'epoch', 'ever')
+          assert_not_contains('worst', 'epoch', 'ever', message='claim this is not in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -241,7 +241,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains('claim this is not in there', 'worst', 'time', 'ever') # 'time' causes this to fail
+          assert_not_contains('worst', 'time', 'ever', message='claim this is not in there') # 'time' causes this to fail
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -256,7 +256,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains_some('claim this is not in there', 'best', 'of', 'times')
+          assert_not_contains_some('best', 'of', 'times', message='claim this is not in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -271,7 +271,7 @@ test:
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains_some('claim this is not in there', 'best', 'of', 'epochs')
+          assert_not_contains_some('best', 'of', 'epochs', message='claim this is not in there')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
@@ -336,7 +336,7 @@ test:
           shell('/bin/echo', '"It was the best of times"')
           extract_match('It was the best of (.*)', 'the_best_of')
           shell('/bin/echo', 'Captured: {}'.format(the_best_of))
-          assert_contains('', 'Captured: times')
+          assert_contains('Captured: times')
     - name: "yaml"
       spec:
       - shell:
@@ -360,7 +360,7 @@ test:
             group_variables=['first_capture', 'second_capture', 'third_capture'])
           shell('/bin/echo', 'First: ', first_capture, 'Second:', second_capture,
             'Third:', third_capture)
-          assert_contains('', 'First: It Second: the best Third: None')
+          assert_contains('First: It Second: the best Third: None')
     - name: "yaml"
       spec:
       - shell:

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -25,16 +25,18 @@ test:
       - code: |
           _, out = shell('/bin/echo', '"It was the bEsT of times"')
           assert_success("echo should have succeeded")
-          assert_contains("BeSt")
-          assert_not_contains("wOrSt")
+          assert_contains('', "BeSt")
+          assert_not_contains('', "wOrSt")
+          assert_contains_any('', 'commonest', 'best', 'worst')
+          assert_not_contains_some('', 'best', 'worst')
           assert_that('ime' in out, 'expected "ime" in the preceding output')
           expect('ime' in out, 'expected "ime" in the preceding output')
           assert_that('ime' in _last_call_output, 'expected "ime" in the preceding output')
 
           call('output', 'Greetings')
           assert_success("call should have succeeded")
-          assert_contains("ree")
-          assert_not_contains("farewell")
+          assert_contains('', "ree")
+          assert_not_contains('', "farewell")
           assert_that('eti' in _last_call_output, 'expected "eti" in the preceding output')
 
           shell('/nonexistent/dir/foobar')
@@ -60,7 +62,13 @@ test:
       - assert_not_contains:
         - message: "Expected no 'worst'"            
         - literal: "wOrSt"
-          
+      - assert_contains_any:
+        - literal: 'commonest'
+        - literal: 'best'
+        - literal: 'worst'
+      - assert_not_contains_some:
+        - literal: 'best'
+        - literal: 'worst'
       - call:
           sample: 'output'
           args:
@@ -141,7 +149,7 @@ test:
       - code: out = call_may_fail('output', 'Hello')
       - assert_failure:
         - "claim this fails"
-  - name: Failing assert_contains
+  - name: Failing assert_contains, one arg
     cases:
     - name: code
       spec:
@@ -154,19 +162,124 @@ test:
       - assert_contains:
         - message: "claim this is in there"
         - literal: "worst"
-  - name: Failing assert_not_contains
+  - name: Failing assert_contains, multiple args
     cases:
     - name: code
       spec:
       - code: |
           out = call('output', 'It was the best of times')
-          assert_not_contains('claim this is not in there', 'best')  # TODO: reverse these args; they're counterintuitive
+          assert_contains('claim this is in there', 'best', 'of', 'all')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_contains:
+        - message: "claim this is in there"
+        - literal: "best"
+        - literal: "of"
+        - literal: "all"
+  - name: Passing assert_contains_any
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_contains_any('claim this is in there', 'worst', 'time', 'ever')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_contains_any:
+        - message: "claim this is in there"
+        - literal: "worst"
+        - literal: "time"
+        - literal: "ever"
+  - name: Failing assert_contains_any
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_contains_any('claim this is in there', 'worst', 'epoch', 'ever')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_contains_any:
+        - message: "claim this is in there"
+        - literal: "worst"
+        - literal: "epoch"
+        - literal: "ever"
+  - name: Failing assert_not_contains, one arg
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_not_contains('claim this is not in there', 'best')
     - name: yaml
       spec:
       - code: out = call('output', 'It was the best of times')
       - assert_not_contains:
         - message: "claim this is not in there"
         - literal: "best"
+  - name: Passing assert_not_contains, multiple args
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_not_contains('claim this is not in there', 'worst', 'epoch', 'ever')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_not_contains:
+        - message: "claim this is not in there"
+        - literal: "worst"
+        - literal: "epoch"
+        - literal: "ever"
+  - name: Failing assert_not_contains, multiple args
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_not_contains('claim this is not in there', 'worst', 'time', 'ever') # 'time' causes this to fail
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_not_contains:
+        - message: "claim this is not in there"
+        - literal: "worst"
+        - literal: "time" # causes this to fail
+        - literal: "ever"
+  - name: Failing assert_not_contains_some
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_not_contains_some('claim this is not in there', 'best', 'of', 'times')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_not_contains_some:
+        - message: "claim this is not in there"
+        - literal: "best"
+        - literal: "of"
+        - literal: "times"
+  - name: Passing assert_not_contains_some
+    cases:
+    - name: code
+      spec:
+      - code: |
+          out = call('output', 'It was the best of times')
+          assert_not_contains_some('claim this is not in there', 'best', 'of', 'epochs')
+    - name: yaml
+      spec:
+      - code: out = call('output', 'It was the best of times')
+      - assert_not_contains_some:
+        - message: "claim this is not in there"
+        - literal: "best"
+        - literal: "of"
+        - literal: "epochs"
   - name: Failing test when failing assertion stops test case from running next segment (should not error)
     setup:
     - code: |
@@ -223,7 +336,7 @@ test:
           shell('/bin/echo', '"It was the best of times"')
           extract_match('It was the best of (.*)', 'the_best_of')
           shell('/bin/echo', 'Captured: {}'.format(the_best_of))
-          assert_contains('Captured: times')
+          assert_contains('', 'Captured: times')
     - name: "yaml"
       spec:
       - shell:
@@ -247,7 +360,7 @@ test:
             group_variables=['first_capture', 'second_capture', 'third_capture'])
           shell('/bin/echo', 'First: ', first_capture, 'Second:', second_capture,
             'Third:', third_capture)
-          assert_contains('First: It Second: the best Third: None')
+          assert_contains('', 'First: It Second: the best Third: None')
     - name: "yaml"
       spec:
       - shell:


### PR DESCRIPTION
We now allow checking that all elements are or are not included in the last output, and that some elements are or are not included in the last output

* In `TestCase`;
  - rename `_check_contains` to `_check_several`
  - have `_check_contains` take `any` or `all`
  - rename `assert_*contains` methods to clarify semantics (and similar for `expect` variants)
  - expand documentation of these methods
  - implement `{expect,assert}_contains_any`
  - implement `{expect,assert}_not_contains_some`

* For the `contains` functions, make `message` be a kwarg. This affects only the code invocation at the moment.  In the future, we can change the yaml invocation so that message need not be the first element in the list. We could also do this for case sensitivity.

* Simplify string inclusion check: When registering the string inclusion/exclusion functions, generate these functions automatically based on the various condition variants. This reduces code duplication and clarifies the semantics.

* Update documentation for including/excluding any/all strings

