### PR TITLE
Tagging 0.13.1: Generate a manifest file from scratch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ The sample tester allows defining tests once and applying them to
 semantically identical executables (typically runnable code samples)
 instantiated in multiple languages and environments.
 
-Version: 0.13.0
+Version: 0.13.1
 
 **PRE-RELEASE**: This surface is not guaranteed to be stable. Breaking changes will still occur.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Google LLC'
 author = 'Victor Chudnovsky'
 
 # The short X.Y version
-version = '0.13.0'
+version = '0.13.1'
 # The full version, including alpha/beta/rc tags
-release = '0.13.0'
+release = '0.13.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/sampletester/cli.py
+++ b/sampletester/cli.py
@@ -45,7 +45,7 @@ from sampletester import summary
 from sampletester import testplan
 from sampletester import xunit
 
-VERSION = '0.13.0'
+VERSION = '0.13.1'
 EXITCODE_SUCCESS = 0
 EXITCODE_TEST_FAILURE = 1
 EXITCODE_FLAG_ERROR = 2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 setup(
     name='sample-tester',
-    version='0.13.0',
+    version='0.13.1',
 
     license='Apache 2.0',
     author='Victor Chudnovsky',


### PR DESCRIPTION
This contains a tool, grafted onto the sample tester in a not-too-clean way, to generate manifest files from scratch. Submitting/releasing this to unblock sample generation.