### PR TITLE
Support implicit tags: `@manifest_source`, `@manifest_dir`

### DIFF
--- a/docs/defining-tests/manifest-reference.rst
+++ b/docs/defining-tests/manifest-reference.rst
@@ -62,7 +62,11 @@ Here's a generic manifest file illustrating these features:
 Tags for sample-tester
 ----------------------
 
-Some manifest tags are of special interest to the sample test runner:
+You may define an arbitrary set of tags for any and all elements in
+your manifest, the only restriction being that no tag name you specify
+may begin with ``@`` (because that is how we identify "implicit tags";
+see below). Moreover, some manifest tags are of special interest to
+sample-tester:
 
 * ``sample``: The unique ID for the sample.
 * ``path``: The path to the sample source code on disk.
@@ -97,7 +101,17 @@ Some manifest tags are of special interest to the sample test runner:
   sample ``path`` and arguments are appended to the value of this tag
   to form the command line that the tester runs.
 
-**Advanced usage**: you can tell sample-tester to use different key names than the ones above. For example, to use keys ``some_name``, ``how_to_call``, and ``switch_path`` instead of ``sample``, ``invocation``, and ``chdir``, respectively, you would simply specify this flag when calling sample-tester:
+The sample-test runner also automatically adds certain **implicit
+tags** to manifest elements when it reads them from YAML
+files. Implicit tag names all begin with the symbol ``@``:
+
+* ``@manifest_source``: The full path, including filename, to the
+  manifest file from which this particular element was read.
+* ``@manifest_dir``: The directory part of ``@manifest_source``,
+  without the trailing filename.
+  
+
+**Advanced usage**: you can tell sample-tester to use different key names than the ones above. For example, to use keys ``some_name``,  ``how_to_call``, and ``switch_path`` instead of ``sample``,  ``invocation``, and ``chdir``, respectively, you would simply specify  this flag when calling sample-tester:
 
 
   .. code-block:: bash

--- a/sampletester/convention/tag.py
+++ b/sampletester/convention/tag.py
@@ -38,7 +38,7 @@ CHDIR_KEY = 'chdir'
 # This the special character that introduced placeholder strings for the
 # INVOCATION_KEY value. To obtain this special character literally in the
 # invocation (i.e. to escape it), insert it twice in succession.
-PLACEHOLDER_CHAR = '@'
+PLACEHOLDER_CHAR = sample_manifest.RESERVED_SYMBOL_PREFIX
 
 # The substring PLACEHOLDER_ARGS in the INVOCATION_KEY value gets replaced at
 # run time with the arguments to be passed to the artifact.

--- a/tests/testdata/sample_manifest/h_he/12.manifest.yaml
+++ b/tests/testdata/sample_manifest/h_he/12.manifest.yaml
@@ -1,0 +1,21 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: manifest/samples
+schema_version: 3
+samples:
+- model: periodic
+  sample: hydrogen
+- model: periodic
+  sample: helium  

--- a/tests/testdata/sample_manifest/h_he/12.v2.manifest.yaml
+++ b/tests/testdata/sample_manifest/h_he/12.v2.manifest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+sets:
+- model: periodic
+  __items__:
+  - sample: hydrogen
+  - sample: helium  

--- a/tests/testdata/sample_manifest/li_be/34.manifest.yaml
+++ b/tests/testdata/sample_manifest/li_be/34.manifest.yaml
@@ -1,0 +1,21 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: manifest/samples
+schema_version: 3
+samples:
+- model: periodic
+  sample: lithium
+- model: periodic
+  sample: beryllium

--- a/tests/testdata/sample_manifest/li_be/34.v2.manifest.yaml
+++ b/tests/testdata/sample_manifest/li_be/34.v2.manifest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+sets:
+- model: periodic
+  __items__:
+  - sample: lithium
+  - sample: beryllium 


### PR DESCRIPTION
This adds support for implicit tags, which are tags not defined explicitly in the manifest docs but which are applied automatically to all elements in a given manifest doc.

- In particular, all YAML documents in the same YAML stream get the same implicit tags, but documents read from different streams will in general have different implicit tags.

- This means that a manifest held in memory could have different sets of elements, each set with different implicit tags, since in the general case the manifest in memory could come from multiple YAML streams (each containing multiple YAML documents).

This commit implements two such implicit tags, `@manifest_source` (the full path to the source manifest file , including the filename itself), and `@manifest_dir` (the directory of the manifest file). This fixes #73.

- When manifests are passed from a string (as happens in testing this code or maybe in the future when we read from stdin), `@manifest_dir` is empty and `@manifest_source` is whatever descriptive string is provided by caller.