### PR TITLE
Minor stylistic clean-ups

### DIFF
--- a/tests/convention/tag_test.py
+++ b/tests/convention/tag_test.py
@@ -20,7 +20,7 @@ from sampletester.convention import tag
 from sampletester import sample_manifest
 
 _ABS_FILE = os.path.abspath(__file__)
-_ABS_DIR = os.path.split(_ABS_FILE)[0]
+_ABS_DIR = os.path.dirname(_ABS_FILE)
 
 class TestSubstitution(unittest.TestCase):
   def test_substitution(self):

--- a/tests/gen_manifest/gen_manifest_test.py
+++ b/tests/gen_manifest/gen_manifest_test.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from gen_manifest import gen_manifest
 
 _ABS_FILE = os.path.abspath(__file__)
-_ABS_DIR = os.path.split(_ABS_FILE)[0]
+_ABS_DIR = os.path.dirname(_ABS_FILE)
 
 class TestGenManifest(unittest.TestCase):
 

--- a/tests/gen_manifest/gen_manifest_test.py
+++ b/tests/gen_manifest/gen_manifest_test.py
@@ -59,7 +59,7 @@ samples:
   sample: getbook_sample
 """.format(env=ENV, bin=BIN, invocation=INVOCATION,
            chdir=CHDIR, sample_path=sample_path, cwd=gen_manifest_cwd)
-    self.assertEquals(expected_string, manifest_string)
+    self.assertEqual(expected_string, manifest_string)
 
   def test_generation_v3_factored_forbidden_tag(self):
     self.maxDiff = None
@@ -110,7 +110,7 @@ samples:
   path: {sample_path}/getbook.py
   sample: getbook_sample
 """.format(env=ENV, bin=BIN, invocation=INVOCATION, chdir=CHDIR, sample_path=sample_path)
-    self.assertEquals(expected_string, manifest_string)
+    self.assertEqual(expected_string, manifest_string)
 
   def test_generation_v3_flat_forbidden_tag(self):
     self.maxDiff = None
@@ -156,7 +156,7 @@ sets:
     sample: getbook_sample
 """.format(env=ENV, bin=BIN, invocation=INVOCATION, chdir=CHDIR, cwd=gen_manifest_cwd,
            sample_path=sample_path)
-    self.assertEquals(expected_string, manifest_string)
+    self.assertEqual(expected_string, manifest_string)
 
   def test_generation_v2_factored_forbidden_tag(self):
     self.maxDiff = None

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -41,7 +41,7 @@ who: dan
     found = {}
     for _, doc, _ in all_parsed:
       found[doc["who"]] = True
-    self.assertEquals(4, len(found))
+    self.assertEqual(4, len(found))
     self.assertTrue(all([name in found for name in ['alice', 'bob', 'carol', 'dan']]))
 
   def test_read_no_version(self):
@@ -462,9 +462,9 @@ who: dan
             "Pb": "lead"
         }
     ]
-    self.assertEquals(expected, sample_manifest.extend_all_with(add, manifest))
-    self.assertEquals(manifest, sample_manifest.extend_all_with(None, manifest))
-    self.assertEquals(None, sample_manifest.extend_all_with(add, None))
+    self.assertEqual(expected, sample_manifest.extend_all_with(add, manifest))
+    self.assertEqual(manifest, sample_manifest.extend_all_with(None, manifest))
+    self.assertEqual(None, sample_manifest.extend_all_with(add, None))
 
   def test_check_tag_names(self):
     invalid_manifest = [
@@ -490,7 +490,7 @@ who: dan
           "Be@": "Beryllium",
       }
     ]
-    self.assertEquals(correct_manifest,
+    self.assertEqual(correct_manifest,
                       sample_manifest.check_tag_names(correct_manifest))
 
   def test_read_files_with_implicit_tags(self):


### PR DESCRIPTION
- Use `os.path.dirname()` when getting path to test file
- s/`self.assertEquals`/`self.assertEqual`/g