### PR TITLE
Allow manifest tag interpolation in format strings in the test plan

### DIFF
--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -26,6 +26,8 @@ test:
       
     - name: "A test defined via yaml directives"
       spec:
+      - log:
+          - 'Reading from manifest at {language_analyze_sentiment_text:@manifest_source}'
       - call:
           sample: "language_analyze_sentiment_text"
           params:
@@ -54,6 +56,8 @@ test:
     - name: "A test defined via 'code'"
       spec:
       - code: |
+          log('Reading from manifest at {language_analyze_sentiment_text:@manifest_source}')
+          
           out = call("language_analyze_sentiment_text", content="happy happy smile hope")
           assert_success("that should have worked", "well")
 

--- a/docs/defining-tests/testplan-reference.rst
+++ b/docs/defining-tests/testplan-reference.rst
@@ -18,7 +18,20 @@ how to run the samples and what checks to perform.
    directives and arguments. The directives can be any of the
    following YAML directives:
    
-   - ``log``: print the arguments, printf style
+   - ``log``: print the arguments, printf style.
+      - Substrings of the form ``{}`` are interpolated with the corresponding positional arguments specified
+      - Substrings of the form ``{id:name}`` are substituted with the
+        value of the manifest tag corresponding to the key ``name``
+        for the sample identified by ``id``. This can be useful when
+        debugging your test to make sure that all the tags are as you
+        expect.
+         - ``id`` must resolve to a sample ID specified in the
+           manifest file
+         - if ``name`` does not match any tag key for the sample
+           ``id``, the substring is substituted with the empty string
+         - if ``name`` is not specified, the substring is substituted
+           with a serialized representation of all the tags specified
+           for the sample ``id``
    - ``uuid``: return a uuid (if called from yaml, assign it to the
      variable names as an argument)
    - ``shell``: run in the shell the command specified in the argument

--- a/sampletester/testenv.py
+++ b/sampletester/testenv.py
@@ -38,6 +38,14 @@ class Base:
     logging.fatal(
         'get_call() invoked on Base (should be overridden)')
 
+  def get_symbol(self, symbol):
+    """Returns a symbol defined in this environment.
+
+    It is up to each environment to define the exact semantics of this.
+    """
+    logging.fatal(
+        'get_symbol() invoked on Base (should be overridden)')
+
   def get_testcase_settings(self):
     """Returns testenv parameters to be used by the test runner"""
     return {}

--- a/tests/caserunner_test.py
+++ b/tests/caserunner_test.py
@@ -16,6 +16,7 @@
 import unittest
 import os
 
+from sampletester import caserunner
 from sampletester import convention
 from sampletester import environment_registry
 from sampletester import runner
@@ -183,6 +184,21 @@ class TestChdir(unittest.TestCase):
       self.assertTrue(self.results.cases[suite_name + ':code'].success(),
                       'expected suite to pass: {}'.format(suite_name))
 
+class TestSymbolInterpolation(unittest.TestCase):
+  def test_symbol_interpolation(self):
+    resolver_dict = {
+        "H": "hydrogen",
+        "He": "helium",
+        "Li": "lithium"
+    }
+    resolver = lambda name: resolver_dict.get(name, '')
+    self.assertEqual('Start with hydrogen, helium, and lithium',
+                     caserunner.interpolate_symbols(
+                         'Start with {H}, {He}, and {Li}',
+                         resolver))
+    self.assertEqual('Want hydrogen or ?',
+                     caserunner.interpolate_symbols('Want {H} or {Ur}?',
+                                                    resolver))
 
 def full_path(leaf_path):
   return os.path.join(_ABS_DIR, leaf_path)

--- a/tests/convention/tag_test.py
+++ b/tests/convention/tag_test.py
@@ -150,6 +150,31 @@ class TestChangingChdirKey(unittest.TestCase):
   def test_chdir(self):
     self.assertEqual('/the/correct/dir', self.get_dir_only('with-alternate-chdir'))
 
+
+class TestGetSymbol(unittest.TestCase):
+  def setUp(self):
+    self.manifest_file_name = full_path('testdata/tag_test.manifest.yaml')
+    manifest = sample_manifest.Manifest('situation')
+    manifest.read_files(self.manifest_file_name)
+    manifest.index()
+    self.env = tag.ManifestEnvironment(self.manifest_file_name, '', manifest, [])
+
+  def test_get_symbol(self):
+    self.assertEqual('Ecuador @args is a @@country',
+                     self.env.get_symbol('invocation-with-placeholder:invocation'))
+
+    expected_full = {'situation': 'invocation-with-placeholder',
+                     'invocation': 'Ecuador @args is a @@country',
+                     'environment': 'Valid call',
+                     '@manifest_source': self.manifest_file_name,
+                     '@manifest_dir': os.path.dirname(self.manifest_file_name)
+                     }
+    self.assertEqual(str(expected_full),
+                     self.env.get_symbol('invocation-with-placeholder'))
+    self.assertEqual(str(expected_full),
+                     self.env.get_symbol('invocation-with-placeholder:'))
+
+
 def full_path(leaf_path):
   return os.path.join(_ABS_DIR, leaf_path)
 


### PR DESCRIPTION
In format strings, any substrings of the form `{samplename:tagname}` will be replaced by the tag value corresponding to the tag key `tagname` for the artifact identified by `samplename`. This fixes #81 

 - If `samplename` does not resolve to a valid artifact, an exception is raised.

 - If `tagname` does not resolve to a valid tag key for `artifact`, an empty string is used as the interpolated value.

 - If `tagname` is not specified, all the tags for `samplename` are serialized into a string used as the interpolated value.

This includes tests and updates to the documentation.