### PR TITLE
Make setup failures preempt test case

### DIFF
--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -403,4 +403,5 @@ test:
           - third_capture # not matched
       - assert_success:
         - if extract_match fails, this is not run
-
+        
+    

--- a/tests/testdata/caserunner_test_setup_failures.yaml
+++ b/tests/testdata/caserunner_test_setup_failures.yaml
@@ -1,0 +1,64 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test:
+  suites:
+  - name: exception_suite
+    setup:
+    - code: |
+        import tempfile
+        f = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+        log('filename: {}'.format(f.name))
+        f.write('setup-before\n')
+        raise Exception('an exception failure')
+        f.write('setup-after\n')
+    cases:
+    - name: "code"
+      spec:
+      - code: |
+          f.write('exception_suite:code\n')
+    - name: "yaml"
+      spec:
+      - log:
+        - 'should not be reached'
+      - code: |
+          f.write('exception_suite:yaml\n')
+    teardown:
+    - code: |
+        f.write('teardown\n')
+        f.close()
+  - name: assertion_suite
+    setup:
+    - code: |
+        import tempfile
+        f = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+        log('filename: {}'.format(f.name))
+        f.write('setup-before\n')
+        assert_that(False, 'an assertion failure')
+        f.write('setup-after\n')
+    cases:
+    - name: "code"
+      spec:
+      - code: |
+          f.write('assertion_suite:code\n')
+    - name: "yaml"
+      spec:
+      - log:
+        - 'should not be reached'
+      - code: |
+          f.write('assertion_suite:yaml\n')
+    teardown:
+    - code: |
+        f.write('teardown\n')
+        f.close()


### PR DESCRIPTION
Each test case is preceded by a setup run specified at the suite level. With this change, if the setup fails, the test case body is not run and we jump directly to the case teardown (also specified at the suite level). Note that if the the suite contains multiple test cases, this process will happen for each test case where the setup fails.

Fixes #85