### PR TITLE
Re-enable "assert_not_contains"

### DIFF
--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -51,6 +51,9 @@ test:
       - assert_excludes:
           - message: "Random message"
           - literal: "The rain in Spain falls mainly in the plain"
+      - assert_not_contains:        # deprecated: use "assert_excludes" instead
+          - message: "Random message"
+          - literal: "The rain in Spain falls mainly in the plain"
 # Above is the typical usage
 
     - name: "A test defined via 'code'"
@@ -77,6 +80,9 @@ test:
           assert_that(magnitude > 0.7, 'magnitude is high')
 
           assert_excludes("the rain in Spain", message="random message")
+
+          # deprecated: use "assert_excludes" instead
+          assert_not_contains("the rain in Spain",message="random message")
           
     - name: "A test defined via 'code', with explicit calls to specific samples"
       spec:

--- a/docs/defining-tests/testplan-reference.rst
+++ b/docs/defining-tests/testplan-reference.rst
@@ -42,9 +42,10 @@ how to run the samples and what checks to perform.
    - ``assert_contains``: require the output of the last ``call*`` to
      contain all of the strings provided (case-insensitively); abort
      the test case otherwise
-   - ``assert_excludes_all``: require the output of the last ``call*``
-     to not contain any of the strings provided (case-insensitively);
-     abort the test case otherwise
+   - ``assert_excludes_all`` (and the previous deprecated form
+     ``assert_not_contains``): require the output of the last
+     ``call*`` to not contain any of the strings provided
+     (case-insensitively); abort the test case otherwise
    - ``assert_contains_any``: require the output of the last ``call*``
      to contain at least one of the strings provided
      (case-insensitively); abort the test case otherwise

--- a/examples/convention-cloud/product_search_test.yaml
+++ b/examples/convention-cloud/product_search_test.yaml
@@ -35,6 +35,8 @@ test:
           sample: "examples/testdata/samples/vision/product-search/list_products.py"
       - assert_excludes:
           - variable: product_id
+      - assert_not_contains:
+          - variable: product_id
       - call:
           sample: "examples/testdata/samples/vision/product-search/create_product.py"
           args:
@@ -53,6 +55,8 @@ test:
       - call:
           sample: "examples/testdata/samples/vision/product-search/list_products.py"
       - assert_excludes:
+          - variable: product_id
+      - assert_not_contains:
           - variable: product_id
 
 

--- a/sampletester/caserunner.py
+++ b/sampletester/caserunner.py
@@ -88,6 +88,10 @@ class TestCase:
         # does not contain any of a list (all list elements absent)
         "assert_excludes": (self.contain_checker(self.assert_that, all, False),
                                 self.params_for_contains),
+        # alias for "assert_excludes"
+        "assert_not_contains": (self.contain_checker(self.assert_that, all, False),
+                                self.params_for_contains),
+
         # contains all of a list
         "assert_contains": (self.contain_checker(self.assert_that, all, True),
                                 self.params_for_contains),

--- a/tests/testdata/caserunner_test.yaml
+++ b/tests/testdata/caserunner_test.yaml
@@ -27,6 +27,7 @@ test:
           assert_success("echo should have succeeded")
           assert_contains("BeSt")
           assert_excludes("wOrSt")
+          assert_not_contains("wOrSt")
           assert_contains_any('commonest', 'best', 'worst')
           assert_excludes_any('best', 'worst')
           assert_that('ime' in out, 'expected "ime" in the preceding output')
@@ -37,6 +38,7 @@ test:
           assert_success("call should have succeeded")
           assert_contains("ree")
           assert_excludes("farewell")
+          assert_not_contains("farewell")
           assert_that('eti' in _last_call_output, 'expected "eti" in the preceding output')
 
           shell('/nonexistent/dir/foobar')
@@ -62,6 +64,9 @@ test:
       - assert_excludes:
         - message: "Expected no 'worst'"            
         - literal: "wOrSt"
+      - assert_not_contains:
+        - message: "Expected no 'worst'"            
+        - literal: "wOrSt"
       - assert_contains_any:
         - literal: 'commonest'
         - literal: 'best'
@@ -79,6 +84,9 @@ test:
           - message: "should contain ree"
           - literal: "ree"
       - assert_excludes:
+          - message: "should not contain farewell"
+          - literal: "farewell"
+      - assert_not_contains:
           - message: "should not contain farewell"
           - literal: "farewell"
 


### PR DESCRIPTION
This is now an alias for "assert_excludes", but is marked deprecated in the docs.