### PR TITLE
Allow unescaped `@` in test.yaml

### DIFF
--- a/docs/defining-tests/language.test.yaml
+++ b/docs/defining-tests/language.test.yaml
@@ -32,7 +32,7 @@ test:
           sample: "language_analyze_sentiment_text"
           params:
             content:
-              literal: "happy happy smile hope"
+              literal: "happy happy smile @hope"
       - assert_success: [] # try assert_failure to see how failure looks
       - assert_contains:
           - message: "Have score and magnitude"

--- a/tests/convention/testdata/tag_test.manifest.yaml
+++ b/tests/convention/testdata/tag_test.manifest.yaml
@@ -19,7 +19,9 @@ sets:
   - situation: simple
     invocation: "Zimbabwe is a country"
   - situation: invocation-with-placeholder
-    invocation: "Ecuador @args is a @@country"
+    invocation: "Ecuador @args is @@a @country"
+  - situation: invocation-with-escaped-placeholder
+    invocation: "Japan @@args is @@a @country"
   - situation: invocation-via-bin-no-path
     bin: "France is a country"
   - situation: invocation-via-bin-with-path
@@ -31,8 +33,6 @@ sets:
   __items__:
   - situation: no-invocation-bin-path
     foo: bar
-  - situation: invocation-with-unescaped-@
-    invocation: "Cambodia is a @country"
 - environment: Changing invocation key
   __items__:
   - situation: alternate-invocation


### PR DESCRIPTION
Previously, any uses of `@` in the test.yaml had to be escaped by including them as `@@`. This was done to have a clear separation between literal `@` passed to the underling process (eg in a `call`) and `@` to be interpreted by sample-tester (currently, only `@args`). The idea was to allow for more substitutions later.

NOW: Since the need to pass `@` to the underlying process does come up from time to time, this PR changes the semantics so that `@foo` is passed verbatim if `@foo` is not a recognized substitution; currently only `@args` is recognized. If the user wishes to pass a recognized substitution (i.e., `"@args"`) to the underlying process, then the `@` must be escaped

tl;dr:
`@args`  → substitution:             `--arg1=val1 --arg2=val2`
`@foo`   → no substitution:          `@foo`
`@@args` → escaped, no substitution: `@args`
`@@foo`  → escaped, no substitution: `@foo`