### PR TITLE
CircleCI: Look for Python syntax errors and undefined names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,14 @@ jobs:
   build:
     working_directory: ~/sample-tester
     docker:
-      - image: circleci/python:3.7.2
+      - image: circleci/python:3.7.4
     steps:
       - checkout
       - run:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --upgrade pip setuptools
+            pip install --upgrade flake8 pip setuptools
+            flake8 . --count --exclude=./.*,./venv --select=E9,F63,F7,F82 --show-source --statistics
             pipenv install .
             . devcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,5 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade flake8 pip setuptools
-            flake8 . --count --exclude=./.*,./venv --select=E9,F63,F7,F82 --show-source --statistics
             pipenv install .
             . devcheck

--- a/tests/test-flake8.sh
+++ b/tests/test-flake8.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cmd='python3 -m flake8 . --count --exclude=./.*,./venv,./build --select=E9,F63,F7,F82 --show-source --statistics'
+echo -e "Checking for python errors:\n  ${cmd}"
+${cmd}


### PR DESCRIPTION
```
./examples/mock-samples/samples/vision/product-search/delete_product.py:16:4: E999 SyntaxError: invalid syntax
cd $(dirname "${BASH_SOURCE[0]}")
   ^
./examples/mock-samples/samples/vision/product-search/list_products.py:16:4: E999 SyntaxError: invalid syntax
cd $(dirname "${BASH_SOURCE[0]}")
   ^
./examples/mock-samples/samples/vision/product-search/create_product.py:16:4: E999 SyntaxError: invalid syntax
cd $(dirname "${BASH_SOURCE[0]}")
   ^
./sampletester/sample_manifest.py:239:19: F821 undefined name 'keys'
      tags = tags[keys[idx]]
                  ^
./sampletester/sample_manifest.py:289:11: F821 undefined name 'SyntaxEror'
    raise SyntaxEror('missing item list name in "{}" field: "{}"'
          ^
./sampletester/convention/cloud/cloud.py:97:27: F821 undefined name 'Call'
    def call_mapper(call: Call):
                          ^
3     E999 SyntaxError: invalid syntax
3     F821 undefined name 'Call'
6
```