### PR TITLE
Support command line containing no file specs

### DIFF
--- a/docs/defining-tests/sample.manifest.yaml
+++ b/docs/defining-tests/sample.manifest.yaml
@@ -46,11 +46,11 @@ python: &python
   bin: python3  # used to run these items
   base_path: "/home/nobody/api/samples/"  
 samples:
-- << *python
+- <<: *python
   path: "{base_path}/trivial/method/sample_alice"
   sample: "alice2"
   canonical: "trivial"
-- << *python
+- <<: *python
   path: "{base_path}complex/method/usecase_bob"
   sample: "robert2"
   tag: "guide"

--- a/examples/convention-tag/test-implicit-files
+++ b/examples/convention-tag/test-implicit-files
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This tests that implicit files are correctly picked up and tested.
+
+# Exit correctly depending on whether this file is being sourced or executed.
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && EXIT=return || EXIT=exit
+
+output_file="$(mktemp /tmp/sample-tester.XXXXXXXXX )"
+invocation_dir="$(mktemp -d /tmp/sample-tester.implicit.XXXXXXXXX )"
+
+pushd "$(dirname ${BASH_SOURCE})/../.." >& /dev/null
+
+# Copy tests, manifests, and samples to a temp directory. Then tweak the
+# manifest to point to the new locations
+cp -ax examples/mock-samples/* ${invocation_dir}/
+cp -L examples/convention-tag/language.{test,manifest}.yaml ${invocation_dir}/
+pushd ${invocation_dir} >& /dev/null
+sed -i 's^examples/mock-samples/^^g' language.manifest.yaml
+
+sample-tester -v detailed ${FLAGS:---xunit=/tmp/xunit.tag.xml} examples/convention-tag/language.test.yaml examples/convention-tag/language.manifest.yaml >& $output_file 
+code=$?
+
+if [[ $code -eq 0 ]] ; then
+  for expected_text in                        \
+    'In setup'  \
+    'In teardown'  \
+    'Language samples test'  \
+    'A test defined via yaml directives'  \
+    "A test defined via 'code'" \
+    ;
+  do
+    if ! grep --silent "$expected_text" "$output_file"; then
+      echo "Assertion failed"
+      echo "Expected \`$expected_text\` in $output_file"
+      code=1
+      break
+    fi
+  done
+else
+  cat $output_file
+fi
+
+popd 2 >& /dev/null
+${EXIT} $code

--- a/examples/convention-tag/test-implicit-files
+++ b/examples/convention-tag/test-implicit-files
@@ -21,17 +21,17 @@
 
 output_file="$(mktemp /tmp/sample-tester.XXXXXXXXX )"
 invocation_dir="$(mktemp -d /tmp/sample-tester.implicit.XXXXXXXXX )"
+example_dir="${invocation_dir}/examples/mock-samples"
+mkdir -p $example_dir
 
 pushd "$(dirname ${BASH_SOURCE})/../.." >& /dev/null
 
-# Copy tests, manifests, and samples to a temp directory. Then tweak the
-# manifest to point to the new locations
-cp -ax examples/mock-samples/* ${invocation_dir}/
+# Copy tests, manifests, and samples to a temp directory.
+cp -ax examples/mock-samples/* ${example_dir}/
 cp -L examples/convention-tag/language.{test,manifest}.yaml ${invocation_dir}/
 pushd ${invocation_dir} >& /dev/null
-sed -i 's^examples/mock-samples/^^g' language.manifest.yaml
 
-sample-tester -v detailed ${FLAGS:---xunit=/tmp/xunit.tag.xml} examples/convention-tag/language.test.yaml examples/convention-tag/language.manifest.yaml >& $output_file 
+sample-tester -v detailed ${FLAGS:---xunit=/tmp/xunit.tag.xml} >& $output_file 
 code=$?
 
 if [[ $code -eq 0 ]] ; then
@@ -51,6 +51,7 @@ if [[ $code -eq 0 ]] ; then
     fi
   done
 else
+  echo "*** Error running from ${invocation_dir}"
   cat $output_file
 fi
 

--- a/sampletester/cli.py
+++ b/sampletester/cli.py
@@ -69,6 +69,7 @@ def main():
 
   if args.version:
     print("sampletester version {}".format(VERSION))
+    exit(EXITCODE_SUCCESS)
 
   log_level = LOG_LEVELS[args.logging] or DEFAULT_LOG_LEVEL
   logging.basicConfig(level=log_level)
@@ -209,10 +210,6 @@ def parse_cli():
       help=("stop execution as soon as any test case fails, preempting " +
             "additional test cases/suites/environments from running"),
       action="store_true")
-
-  if len(sys.argv) == 1:
-    parser.print_help()
-    return None, None
 
   parser.add_argument("files", metavar="CONFIGS", nargs=argparse.REMAINDER)
   return parser.parse_args(), parser.format_usage()

--- a/sampletester/inputs.py
+++ b/sampletester/inputs.py
@@ -66,6 +66,9 @@ def index_docs(*file_patterns: str) -> parser.IndexedDocs:
 
   Returns: the indexed docs of the files that were searched for.
   """
+  if not file_patterns:
+    file_patterns = ['**/*.yaml']
+
   explicit_paths = get_globbed(*file_patterns)
   explicit_directories = {path for path in explicit_paths
                           if os.path.isdir(path)}

--- a/sampletester/parser.py
+++ b/sampletester/parser.py
@@ -101,7 +101,7 @@ class IndexedDocs(object):
     provided, the untyped documents are put into their own list with type given
     by `SCHEMA_TYPE_ABSENT`.
     """
-    self.add_documents(*[Document(file_name, doc) for doc in yaml.load_all(content)])
+    self.add_documents(*[Document(file_name, doc) for doc in yaml.safe_load_all(content)])
 
   def add_documents(self, *documents: Document):
     """Adds each doc in `documents` under the right schema type key."""
@@ -111,17 +111,17 @@ class IndexedDocs(object):
                         else None)
 
       if not specified_type:
-        msg = f'no top-level "{SCHEMA_TYPE_KEY}" field specified'
+        msg = f'no top-level "{SCHEMA_TYPE_KEY}" field specified in {doc.path}'
         if self.strict:
           raise YamlDocSyntaxError(msg)
-        logging.warning(msg)
+        logging.info(msg)
 
       if not isinstance(specified_type, str):
         msg = (f'top level "{SCHEMA_TYPE_KEY}" field is not '
-               f'a string: {specified_type}')
+               f'a string: ({specified_type})')
         if self.strict:
           raise YamlDocSyntaxError(msg)
-        logging.warning(msg)
+        logging.info(msg)
         specified_type = SCHEMA_TYPE_ABSENT
 
       type_name = specified_type.split(SCHEMA_TYPE_SEPARATOR, 1)[0]


### PR DESCRIPTION
I had accidentally left out support for this in #105 . This adds support for calling `sample-tester` with no command-line arguments, picking up files recursively from the cwd.

This includes a test for this type of invocation!

This fixes #113 
This fixes #114 
This fixes #52 