### PR TITLE
Fix logging; raise when expecting one key and finding multiple

### DIFF
--- a/sampletester/cli.py
+++ b/sampletester/cli.py
@@ -71,9 +71,9 @@ def main():
     print("sampletester version {}".format(VERSION))
     exit(EXITCODE_SUCCESS)
 
-  log_level = LOG_LEVELS[args.logging] or DEFAULT_LOG_LEVEL
-  logging.basicConfig(level=log_level)
-  logging.info("argv: {}".format(sys.argv))
+  log_level = LOG_LEVELS[args.logging] or LOG_LEVELS[DEFAULT_LOG_LEVEL]
+  logging.getLogger().setLevel(log_level)
+  logging.debug("argv: {}".format(sys.argv))
 
   try:
     indexed_docs = inputs.index_docs(*args.files)
@@ -128,7 +128,7 @@ def main():
   exit(EXITCODE_SUCCESS if success else EXITCODE_TEST_FAILURE)
 
 
-LOG_LEVELS = {"none": None, "info": logging.INFO, "debug": logging.DEBUG}
+LOG_LEVELS = {"none": logging.WARNING, "info": logging.INFO, "debug": logging.DEBUG}
 DEFAULT_LOG_LEVEL = "none"
 
 VERBOSITY_LEVELS = {"quiet": summary.Detail.NONE, "summary": summary.Detail.BRIEF, "detailed": summary.Detail.FULL}

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -115,7 +115,7 @@ class Manifest:
     err_no_interpreter = []
     sources_read = []
     for name, manifest, implicit_tags in sources:
-      logging.info('reading manifest "{}"'.format(name))
+      logging.debug('reading manifest "{}"'.format(name))
       if not manifest:
         continue
       sources_read.append(name)
@@ -193,7 +193,7 @@ class Manifest:
                              [] if idx_num >= max_idx else {})
       tags.append(element) # appending to the  non-indexed list
 
-    logging.info('indexed elements')
+    logging.debug('indexed elements')
 
   def get_all_elements(self):
     """Generator that yields each element in the (indexed) manifest."""
@@ -309,7 +309,7 @@ def get_flattened_elements_v1_v2(input):
       for key, common_value in set_common_values.items():
         element[key] = common_value + element.get(key, '')
       element_list.append(element)
-      logging.info('read "{}"'.format(element))
+      logging.debug('read "{}"'.format(element))
   return element_list
 
 
@@ -328,7 +328,7 @@ def resolve_inclusions(all_elements):
     return None
   for element in all_elements:
     resolve_element_inclusions(element)
-  logging.info('resolved inclusions')
+  logging.debug('resolved inclusions')
   return all_elements
 
 def resolve_element_inclusions(element):

--- a/sampletester/sample_manifest.py
+++ b/sampletester/sample_manifest.py
@@ -247,8 +247,12 @@ class Manifest:
   def get_one(self, *keys, **filters):
     """Returns the single artifact associated with these keys and filters, or None otherwise"""
     values = self.get(*keys, **filters)
-    if values is None or len(values) != 1:
+    if not values:
       return None
+    if len(values) > 1:
+      requested = {self.indices[idx]: key_value for idx, key_value in  enumerate(keys)}
+      requested.update(filters)
+      raise ItemNotUniqueError(f'more than one item with the requested fields {requested}')
     return values[0]
 
 
@@ -530,3 +534,6 @@ def check_tag_names(src):
                       .format(RESERVED_SYMBOL_PREFIX,
                               ' '.join(['"{}"'.format(name) for name in invalid])))
   return src # to allow for composition
+
+class ItemNotUniqueError(Exception):
+  pass

--- a/tests/sample_manifest_test.py
+++ b/tests/sample_manifest_test.py
@@ -168,7 +168,8 @@ who: dan
 
     self.assertIsNone(manifest.get_one('foo', 'alice'))
 
-    self.assertIsNone(manifest.get_one('', 'math'))
+    self.assertRaises(sample_manifest.ItemNotUniqueError,
+                      manifest.get_one, '', 'math')
 
   def test_get_all_elements(self):
     manifest_source, (expect_alice, expect_bob, expect_carol,

--- a/tests/sample_manifest_v1v2_test.py
+++ b/tests/sample_manifest_v1v2_test.py
@@ -107,7 +107,8 @@ class TestManifestV1V2(unittest.TestCase):
 
     self.assertIsNone(manifest.get_one('foo', 'alice'))
 
-    self.assertIsNone(manifest.get_one('', 'math'))
+    self.assertRaises(sample_manifest.ItemNotUniqueError,
+                      manifest.get_one, '', 'math')
 
   def test_get_all_elements(self):
     manifest_source, (expect_alice, expect_bob, expect_carol,


### PR DESCRIPTION
Raise ItemNotUniqueError from get_one() when >1 item matches
- Includes test

Fix logging; log manifests and testplans
- Fixed the logging level for sample-tester binary
- Set a few logging statements to be `debug` rather than `info`
- We now report the manifest and testplan files read in via `logging.info()`

(These changes needed to happen eventually and they were helpful in debugging an issue.)